### PR TITLE
Fix mirror source settings not persisting after restart

### DIFF
--- a/app.go
+++ b/app.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -21,6 +22,9 @@ import (
 )
 
 var Version = "0.dev"
+
+// Application data directory name (stored in user's home directory)
+const appDataDir = ".wailbrew"
 
 // Standard PATH and locale for brew commands
 const brewEnvPath = "PATH=/opt/homebrew/sbin:/opt/homebrew/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"
@@ -766,6 +770,60 @@ type NewPackagesInfo struct {
 	NewCasks    []string `json:"newCasks"`
 }
 
+// Config represents the application configuration stored in ~/.wailbrew/config.json
+type Config struct {
+	GitRemote    string `json:"gitRemote"`
+	BottleDomain string `json:"bottleDomain"`
+}
+
+// getConfigPath returns the path to the config file
+func getConfigPath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, appDataDir, "config.json"), nil
+}
+
+// Load loads the configuration from ~/.wailbrew/config.json
+func (c *Config) Load() error {
+	configPath, err := getConfigPath()
+	if err != nil {
+		return err
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // No config file yet, use defaults
+		}
+		return err
+	}
+
+	return json.Unmarshal(data, c)
+}
+
+// Save saves the configuration to ~/.wailbrew/config.json
+func (c *Config) Save() error {
+	configPath, err := getConfigPath()
+	if err != nil {
+		return err
+	}
+
+	// Create directory if it doesn't exist
+	configDir := filepath.Dir(configPath)
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(configPath, data, 0644)
+}
+
 // App struct
 type App struct {
 	ctx                context.Context
@@ -778,8 +836,7 @@ type App struct {
 	knownPackagesMutex sync.Mutex
 	sessionLogs        []string   // Session logs for debugging
 	sessionLogsMutex   sync.Mutex // Mutex for thread-safe log access
-	gitRemote          string     // HOMEBREW_GIT_REMOTE mirror source
-	bottleDomain       string     // HOMEBREW_BOTTLE_DOMAIN mirror source
+	config             *Config    // Application configuration
 }
 
 // detectBrewPath automatically detects the brew binary path
@@ -814,6 +871,7 @@ func NewApp() *App {
 		currentLanguage: "en",
 		knownPackages:   make(map[string]bool),
 		sessionLogs:     make([]string, 0),
+		config:          &Config{},
 	}
 }
 
@@ -857,11 +915,11 @@ func (a *App) getBrewEnv() []string {
 	}
 
 	// Add mirror source environment variables if configured
-	if a.gitRemote != "" {
-		env = append(env, fmt.Sprintf("HOMEBREW_GIT_REMOTE=%s", a.gitRemote))
+	if a.config.GitRemote != "" {
+		env = append(env, fmt.Sprintf("HOMEBREW_GIT_REMOTE=%s", a.config.GitRemote))
 	}
-	if a.bottleDomain != "" {
-		env = append(env, fmt.Sprintf("HOMEBREW_BOTTLE_DOMAIN=%s", a.bottleDomain))
+	if a.config.BottleDomain != "" {
+		env = append(env, fmt.Sprintf("HOMEBREW_BOTTLE_DOMAIN=%s", a.config.BottleDomain))
 	}
 
 	return env
@@ -926,6 +984,11 @@ func (a *App) validateBrewInstallation() error {
 // startup saves the application context and sets up the askpass helper
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
+
+	// Load config from file
+	if err := a.config.Load(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to load config: %v\n", err)
+	}
 
 	// Set up the askpass helper for GUI sudo prompts
 	if err := a.setupAskpassHelper(); err != nil {
@@ -3262,8 +3325,8 @@ func (a *App) SetBrewPath(path string) error {
 // GetMirrorSource returns the current mirror source configuration
 func (a *App) GetMirrorSource() map[string]string {
 	return map[string]string{
-		"gitRemote":    a.gitRemote,
-		"bottleDomain": a.bottleDomain,
+		"gitRemote":    a.config.GitRemote,
+		"bottleDomain": a.config.BottleDomain,
 	}
 }
 
@@ -3281,8 +3344,13 @@ func (a *App) SetMirrorSource(gitRemote string, bottleDomain string) error {
 		}
 	}
 
-	a.gitRemote = gitRemote
-	a.bottleDomain = bottleDomain
+	a.config.GitRemote = gitRemote
+	a.config.BottleDomain = bottleDomain
+
+	if err := a.config.Save(); err != nil {
+		return fmt.Errorf("failed to save config: %v", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Fix mirror source settings (gitRemote, bottleDomain) being reset to defaults on app restart.

Closes #75

## Changes

- Add `Config` struct with `Load()` and `Save()` methods for persistent storage
- Add `config *Config` field to `App` struct (replaces `gitRemote`, `bottleDomain` fields)
- Load saved settings from `~/.wailbrew/config.json` on app startup
- Auto-save settings to config file when `SetMirrorSource()` is called
- Use empty values (Homebrew official mirrors) when config file doesn't exist

## Test

First start up:

```shell
> cat ~/.wailbrew/config.json
cat: ~/.wailbrew/config.json: No such file or directory
```
<img width="1024" height="800" alt="image" src="https://github.com/user-attachments/assets/22eb75a2-7366-486b-8dd3-3e5d43b14235" />

Change and save:

```shell
> cat ~/.wailbrew/config.json
{
  "gitRemote": "https://mirrors.tuna.tsinghua.edu.cn/git/homebrew/brew.git",
  "bottleDomain": "https://mirrors.tuna.tsinghua.edu.cn/homebrew-bottles"
}
```
<img width="1024" height="800" alt="image" src="https://github.com/user-attachments/assets/81978f49-1783-4be7-a3fd-c8da24092594" />

After start up:


```shell
> cat ~/.wailbrew/config.json
{
  "gitRemote": "https://mirrors.tuna.tsinghua.edu.cn/git/homebrew/brew.git",
  "bottleDomain": "https://mirrors.tuna.tsinghua.edu.cn/homebrew-bottles"
}
```
<img width="1024" height="800" alt="image" src="https://github.com/user-attachments/assets/81978f49-1783-4be7-a3fd-c8da24092594" />

## Additional Notes

- Defined `~/.wailbrew/` as `appDataDir` constant for future use (e.g., caching for #157 performance improvements)
- Open to discussion if a different storage approach is preferred.
- **Question about Reset behavior:** The current "Reset" button restores the last saved value (cancels unsaved changes). Should it instead reset to default values (official mirrors)? Happy to update if that's the intended behavior.
