### PR TITLE
Optimize brew call performance with caching

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -182,7 +182,7 @@ const WailBrewApp = () => {
             }
         }, 100);
         
-        Promise.all([GetBrewPackages(false), GetBrewCasks(false), GetBrewUpdatablePackages(), GetBrewLeaves(), GetBrewTaps()])
+        Promise.all([GetBrewPackages(), GetBrewCasks(false), GetBrewUpdatablePackages(), GetBrewLeaves(), GetBrewTaps()])
             .then(([installed, installedCasks, updatable, leaves, repos]) => {
                 // Ensure all responses are arrays, default to empty arrays if null/undefined
                 const safeInstalled = installed || [];
@@ -1699,7 +1699,7 @@ const WailBrewApp = () => {
         
         try {
             const [installed, caskList, updatable, leaves, repos] = await Promise.all([
-                GetBrewPackages(true),
+                GetBrewPackages(),
                 GetBrewCasks(true),
                 GetBrewUpdatablePackages(),
                 GetBrewLeaves(),

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -30,7 +30,7 @@ export function GetBrewPackageInfoAsJson(arg1:string):Promise<Record<string, any
 
 export function GetBrewPackageSizes(arg1:Array<string>):Promise<Record<string, string>>;
 
-export function GetBrewPackages(arg1:boolean):Promise<Array<any>>;
+export function GetBrewPackages():Promise<Array<any>>;
 
 export function GetBrewPath():Promise<string>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -58,8 +58,8 @@ export function GetBrewPackageSizes(arg1) {
   return window['go']['main']['App']['GetBrewPackageSizes'](arg1);
 }
 
-export function GetBrewPackages(arg1) {
-  return window['go']['main']['App']['GetBrewPackages'](arg1);
+export function GetBrewPackages() {
+  return window['go']['main']['App']['GetBrewPackages']();
 }
 
 export function GetBrewPath() {


### PR DESCRIPTION
## Summary

- eb29fe4 Cache brew validation at startup
- 5794c0f Add package info cache with refresh parameter
- c3febc8 Persist cache to file for faster app restarts

## Changes

### 1. Cache brew validation at startup (eb29fe4)

**Problem:** Each API function (`GetBrewPackages`, `GetBrewCasks`, etc.) independently validates brew installation, causing `brew --version` to be called 5-6 times at app startup.

**Solution:**

- Validate brew installation once in `startup()`
- Cache result in `brewValidated` and `brewValidationError` fields
- Individual functions check cached state via `checkBrewValidation()`

<details>
<summary>Logs</summary>

**Before:**

```log
[2025-12-14 21:24:41] Executing: brew --version
[2025-12-14 21:24:41] Executing: brew --version
[2025-12-14 21:24:41] Executing: brew --version
[2025-12-14 21:24:41] Executing: brew --version
[2025-12-14 21:24:41] Executing: brew --version
[2025-12-14 21:24:41] Executing: brew --version
[2025-12-14 21:24:41] SUCCESS: brew --version completed
[2025-12-14 21:24:41] SUCCESS: brew --version completed
[2025-12-14 21:24:41] SUCCESS: brew --version completed
[2025-12-14 21:24:41] SUCCESS: brew --version completed
[2025-12-14 21:24:41] SUCCESS: brew --version completed
[2025-12-14 21:24:42] SUCCESS: brew --version completed
```

**After:**

```log
[2025-12-14 21:18:41] Executing: brew --version
[2025-12-14 21:18:42] SUCCESS: brew --version completed
```

</details>

### 2. Add package info cache with refresh parameter (5794c0f)

**Problem:**

- `brew info` is called again when clicking individual packages, even after batch loading
- Refresh button returns cached data instead of fetching latest info

**Solution:**

- Add `Cache` struct to cache package info in memory
- `LoadPackageInfo()`: Only call brew info for uncached packages
- `GetBrewCasks(refresh bool)`: Add refresh parameter
  - `refresh=false`: Keep cache (initial load, normal view)
  - `refresh=true`: Clear cache and reload (Refresh button)

<details>
<summary>Logs</summary>

**Before:** (brew info called again on package click)

```log
# Batch loading
[2025-12-14 22:20:48] Executing: brew info --json=v2 abseil ant aom argocd ... libnghttp2
[2025-12-14 22:20:50] SUCCESS: brew info --json=v2 abseil ant aom argocd ... libnghttp2 completed
[2025-12-14 22:20:50] Executing: brew info --json=v2 libnghttp3 libngtcp2 ... shared-mime-info
[2025-12-14 22:20:51] SUCCESS: brew info --json=v2 libnghttp3 libngtcp2 ... shared-mime-info completed
[2025-12-14 22:20:51] Executing: brew info --json=v2 simdjson simdutf sqlc ... zstd
[2025-12-14 22:20:53] SUCCESS: brew info --json=v2 simdjson simdutf sqlc ... zstd completed

# Called again on package click
[2025-12-14 22:20:58] Executing: brew info --json=v2 abseil
[2025-12-14 22:20:59] SUCCESS: brew info --json=v2 abseil completed
[2025-12-14 22:21:01] Executing: brew info --json=v2 ant
[2025-12-14 22:21:02] SUCCESS: brew info --json=v2 ant completed
[2025-12-14 22:21:03] Executing: brew info --json=v2 aom
[2025-12-14 22:21:04] SUCCESS: brew info --json=v2 aom completed
...
```

**After:** (cache hit on package click)

```log
# Batch loading
[2025-12-14 22:21:53] Executing: brew info --json=v2 abseil ant aom argocd ... libnghttp2
[2025-12-14 22:21:55] SUCCESS: brew info --json=v2 abseil ant aom argocd ... libnghttp2 completed
[2025-12-14 22:21:55] Executing: brew info --json=v2 libnghttp3 libngtcp2 ... shared-mime-info
[2025-12-14 22:21:56] SUCCESS: brew info --json=v2 libnghttp3 libngtcp2 ... shared-mime-info completed
[2025-12-14 22:21:56] Executing: brew info --json=v2 simdjson simdutf sqlc ... zstd
[2025-12-14 22:21:58] SUCCESS: brew info --json=v2 simdjson simdutf sqlc ... zstd completed

# Cache hit on package click (no brew calls)
[2025-12-14 22:22:03] Cache hit: brew info --json=v2 abseil
[2025-12-14 22:22:03] Cache hit: brew info --json=v2 ant
[2025-12-14 22:22:03] Cache hit: brew info --json=v2 aom
...
```

</details>

**Changed files:**

- `app.go`: Add Cache struct, refresh parameter
- `frontend/src/App.tsx`: Pass refresh parameter to calls
- `frontend/wailsjs/go/main/App.js`, `App.d.ts`: Update bindings

### 3. Persist cache to file for Change 2 (c3febc8)

**Problem:** In-memory cache is lost on app restart, requiring `brew info` to be called again every time.

**Solution:**

- Save cache to `~/.wailbrew/cache.json` (uses directory created in #167)
- Save triggers:
  - On app shutdown
  - On Refresh button click

<details>
<summary>Logs</summary>

**First run:** (no cache file, brew info called)

```log
[2025-12-14 23:06:08] Cache loaded: 0 packages
...
[2025-12-14 23:06:12] Executing: brew info --json=v2 abseil ... libnghttp2
[2025-12-14 23:06:14] SUCCESS: brew info --json=v2 abseil ... libnghttp2 completed
[2025-12-14 23:06:15] Executing: brew info --json=v2 simdjson ... zstd
[2025-12-14 23:06:17] SUCCESS: brew info --json=v2 simdjson ... zstd completed
...
```

**Restart:** (cache file exists, significantly fewer brew info calls)

```log
[2025-12-14 22:57:42] Cache loaded: 156 packages
...
```

</details>

**Changed files:**

- `app.go`: Add `Cache.Load()`, `Cache.Save()`

---


## Note: Related to #157

I started this work to address #157.

- Single package queries from the list are now returned instantly from cache, significantly improving performance
- Installed package list is also cached for better performance, but due to `brew formulae` call, the perceived improvement is minimal

Personally, I think replacing the full formulae fetch with on-demand search queries might help.

