### PR TITLE
feat: Implement proxy configuration and testing with dedicated settings UI.

### DIFF
--- a/app.go
+++ b/app.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -200,6 +201,17 @@ func (a *App) getBrewEnv() []string {
 		brewEnvLang,
 		brewEnvLCAll,
 		brewEnvNoAutoUpdate,
+	}
+
+	// Add proxy environment variables if configured
+	if a.config.Proxy != "" {
+		proxy := a.config.Proxy
+		env = append(env, fmt.Sprintf("http_proxy=%s", proxy))
+		env = append(env, fmt.Sprintf("https_proxy=%s", proxy))
+		env = append(env, fmt.Sprintf("all_proxy=%s", proxy))
+		env = append(env, fmt.Sprintf("HTTP_PROXY=%s", proxy))
+		env = append(env, fmt.Sprintf("HTTPS_PROXY=%s", proxy))
+		env = append(env, fmt.Sprintf("ALL_PROXY=%s", proxy))
 	}
 
 	// Add SUDO_ASKPASS if askpass helper is available
@@ -649,6 +661,59 @@ func (a *App) OpenConfigFile() error {
 }
 
 // CONFIG OPERATIONS - Simple delegation to config
+
+func (a *App) GetProxy() string {
+	return a.config.Proxy
+}
+
+func (a *App) SetProxy(proxy string) error {
+	a.config.Proxy = strings.TrimSpace(proxy)
+	if err := a.config.Save(); err != nil {
+		return fmt.Errorf("failed to save config: %v", err)
+	}
+
+	// Update brew executor with new environment
+	if a.brewExecutor != nil {
+		a.brewExecutor = brew.NewExecutor(a.brewPath, a.getBrewEnv(), a.sessionLogManager.Append)
+	}
+
+	return nil
+}
+
+func (a *App) TestProxyConnection(proxyStr, targetUrl string) (string, error) {
+	proxyStr = strings.TrimSpace(proxyStr)
+	targetUrl = strings.TrimSpace(targetUrl)
+
+	if proxyStr == "" {
+		return "", fmt.Errorf("proxy URL is empty")
+	}
+	if targetUrl == "" {
+		return "", fmt.Errorf("target URL is empty")
+	}
+
+	proxyURL, err := url.Parse(proxyStr)
+	if err != nil {
+		return "", fmt.Errorf("invalid proxy URL: %v", err)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyURL(proxyURL),
+		},
+		Timeout: 10 * time.Second,
+	}
+
+	resp, err := client.Get(targetUrl)
+	if err != nil {
+		return "", fmt.Errorf("connection failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return fmt.Sprintf("Success: HTTP %d", resp.StatusCode), nil
+	}
+	return fmt.Sprintf("Failed: HTTP %d", resp.StatusCode), fmt.Errorf("server returned error code: %d", resp.StatusCode)
+}
 
 func (a *App) GetMirrorSource() map[string]string {
 	return map[string]string{

--- a/backend/config/loadsave.go
+++ b/backend/config/loadsave.go
@@ -18,6 +18,7 @@ type Config struct {
 	CustomCaskOpts     string `json:"customCaskOpts"`     // Additional cask options (e.g., "--fontdir=/Library/Fonts --qlplugindir=~/Library/QuickLook")
 	CustomOutdatedArgs string `json:"customOutdatedArgs"` // Additional outdated command arguments (e.g., "--verbose --formula")
 	AdminUsername      string `json:"adminUsername"`      // Admin username for sudo operations (defaults to current user)
+	Proxy              string `json:"proxy"`              // Global proxy setting (e.g., "http://127.0.0.1:7890" or "http://user:pass@127.0.0.1:7890")
 }
 
 // GetConfigPath returns the path to the config file

--- a/frontend/src/components/SettingsView.tsx
+++ b/frontend/src/components/SettingsView.tsx
@@ -14,9 +14,10 @@ import {
     Info,
     Sparkles,
     Code2,
-    Shield
+    Shield,
+    Network
 } from "lucide-react";
-import { GetBrewPath, SetBrewPath, GetMirrorSource, SetMirrorSource, GetOutdatedFlag, SetOutdatedFlag, GetCaskAppDir, SetCaskAppDir, SelectCaskAppDir, GetCustomCaskOpts, SetCustomCaskOpts, GetCustomOutdatedArgs, SetCustomOutdatedArgs, GetAdminUsername, SetAdminUsername, GetMacOSVersion, GetMacOSReleaseName, GetSystemArchitecture } from "../../wailsjs/go/main/App";
+import { GetBrewPath, SetBrewPath, GetMirrorSource, SetMirrorSource, GetOutdatedFlag, SetOutdatedFlag, GetCaskAppDir, SetCaskAppDir, SelectCaskAppDir, GetCustomCaskOpts, SetCustomCaskOpts, GetCustomOutdatedArgs, SetCustomOutdatedArgs, GetAdminUsername, SetAdminUsername, GetMacOSVersion, GetMacOSReleaseName, GetSystemArchitecture, GetProxy, SetProxy, TestProxyConnection } from "../../wailsjs/go/main/App";
 import toast from 'react-hot-toast';
 
 interface SettingsViewProps {
@@ -58,6 +59,14 @@ const SettingsView: React.FC<SettingsViewProps> = ({ onRefreshPackages }) => {
     const [macOSReleaseName, setMacOSReleaseName] = useState<string>("");
     const [systemArchitecture, setSystemArchitecture] = useState<string>("");
 
+    const [proxy, setProxy] = useState<string>("");
+    const [newProxy, setNewProxy] = useState<string>("");
+    const [savingProxy, setSavingProxy] = useState<boolean>(false);
+    const [isProxyExpanded, setIsProxyExpanded] = useState<boolean>(false);
+    const [testProxyUrl, setTestProxyUrl] = useState<string>("https://brew.sh");
+    const [testingProxy, setTestingProxy] = useState<boolean>(false);
+    const [testProxyResult, setTestProxyResult] = useState<{success: boolean, message: string} | null>(null);
+
     useEffect(() => {
         loadCurrentBrewPath();
         loadCurrentMirrorSource();
@@ -67,6 +76,7 @@ const SettingsView: React.FC<SettingsViewProps> = ({ onRefreshPackages }) => {
         loadCustomOutdatedArgs();
         loadAdminUsername();
         loadSystemInfo();
+        loadCurrentProxy();
     }, []);
 
     const loadCurrentBrewPath = async () => {
@@ -136,6 +146,72 @@ const SettingsView: React.FC<SettingsViewProps> = ({ onRefreshPackages }) => {
         }
 
         toast.error(t('settings.errors.autoDetectionFailed'));
+    };
+
+    const loadCurrentProxy = async () => {
+        try {
+            const currentProxy = await GetProxy();
+            setProxy(currentProxy);
+            setNewProxy(currentProxy);
+        } catch (error) {
+            console.error("Failed to get proxy:", error);
+        }
+    };
+
+    const handleSaveProxy = async () => {
+        const trimmedProxy = newProxy.trim();
+        if (trimmedProxy === proxy) {
+            toast.success(t('settings.messages.noChanges'));
+            return;
+        }
+
+        try {
+            setSavingProxy(true);
+            await SetProxy(trimmedProxy);
+            setProxy(trimmedProxy);
+            setNewProxy(trimmedProxy);
+            toast.success(t('settings.messages.proxyUpdated'));
+            onRefreshPackages();
+        } catch (error) {
+            console.error("Failed to set proxy:", error);
+            toast.error(t('settings.errors.failedToSetProxy'));
+            setNewProxy(proxy);
+        } finally {
+            setSavingProxy(false);
+        }
+    };
+
+    const handleResetProxy = () => {
+        setNewProxy(proxy);
+    };
+
+    const handleTestProxy = async () => {
+        if (!testProxyUrl.trim()) {
+            toast.error(t('settings.errors.emptyTestUrl'));
+            return;
+        }
+        
+        try {
+            setTestingProxy(true);
+            setTestProxyResult(null);
+            
+            const proxyToTest = newProxy.trim() || proxy;
+            if (!proxyToTest) {
+                toast.error(t('settings.errors.emptyProxyForTest'));
+                setTestingProxy(false);
+                return;
+            }
+
+            const result = await TestProxyConnection(proxyToTest, testProxyUrl.trim());
+            setTestProxyResult({ success: true, message: result });
+            toast.success(t('settings.messages.proxyTestSuccess'));
+        } catch (error: any) {
+            console.error("Proxy test failed:", error);
+            setTestProxyResult({ success: false, message: error.message || String(error) });
+            toast.error(t('settings.errors.proxyTestFailed'));
+        } finally {
+            setTestingProxy(false);
+        }
     };
 
     const loadCurrentMirrorSource = async () => {
@@ -703,6 +779,114 @@ const SettingsView: React.FC<SettingsViewProps> = ({ onRefreshPackages }) => {
                             >
                                 {savingMirror ? <Loader2 className="spin" size={16} /> : <Check size={16} />}
                                 {savingMirror ? t('settings.buttons.saving') : t('settings.buttons.save')}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Proxy Card */}
+                <div className={`settings-card ${isProxyExpanded ? 'expanded' : ''}`}>
+                    <button 
+                        className="settings-card-header"
+                        onClick={() => setIsProxyExpanded(!isProxyExpanded)}
+                        aria-expanded={isProxyExpanded}
+                    >
+                        <div className="settings-card-icon">
+                            <Network size={20} />
+                        </div>
+                        <div className="settings-card-info">
+                            <h3>{t('settings.proxy.title')}</h3>
+                            <span className="settings-card-value">
+                                {proxy ? proxy : t('settings.proxy.none', 'None')}
+                            </span>
+                        </div>
+                        <ChevronRight className={`settings-card-chevron ${isProxyExpanded ? 'rotated' : ''}`} size={20} />
+                    </button>
+                    
+                    <div className={`settings-card-content ${isProxyExpanded ? 'show' : ''}`}>
+                        <p className="settings-card-description">
+                            {t('settings.proxy.description')}
+                        </p>
+                        
+                        <div className="settings-input-group">
+                            <label>{t('settings.proxy.currentProxy')}</label>
+                            <input
+                                type="text"
+                                value={newProxy}
+                                onChange={(e) => {
+                                    setNewProxy(e.target.value);
+                                    setTestProxyResult(null);
+                                }}
+                                placeholder={t('settings.proxy.placeholder')}
+                                disabled={savingProxy || testingProxy}
+                            />
+                        </div>
+
+                        <div className="settings-input-group" style={{ marginTop: '16px', paddingTop: '16px', borderTop: '1px solid var(--wails-border, #eee)' }}>
+                            <label style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                                <span>{t('settings.proxy.testConnection')}</span>
+                            </label>
+                            <div className="settings-input-row">
+                                <input
+                                    type="text"
+                                    value={testProxyUrl}
+                                    onChange={(e) => setTestProxyUrl(e.target.value)}
+                                    placeholder={t('settings.proxy.testUrlPlaceholder')}
+                                    disabled={savingProxy || testingProxy}
+                                />
+                                <button
+                                    className="settings-btn-secondary"
+                                    onClick={handleTestProxy}
+                                    disabled={savingProxy || testingProxy || !testProxyUrl.trim()}
+                                    style={{ whiteSpace: 'nowrap' }}
+                                    title={t('settings.proxy.testButton')}
+                                >
+                                    {testingProxy ? <Loader2 className="spin" size={16} /> : <Globe size={16} />}
+                                    <span style={{marginLeft: '6px'}}>{testingProxy ? t('settings.proxy.testing') : t('settings.proxy.testButton')}</span>
+                                </button>
+                            </div>
+                            {testProxyResult && (
+                                <div style={{ 
+                                    marginTop: '12px', 
+                                    padding: '10px 12px', 
+                                    borderRadius: '6px', 
+                                    fontSize: '13px',
+                                    color: testProxyResult.success ? 'var(--success-color, #10b981)' : 'var(--error-color, #ef4444)',
+                                    backgroundColor: testProxyResult.success ? 'rgba(16, 185, 129, 0.1)' : 'rgba(239, 68, 68, 0.1)',
+                                    display: 'flex',
+                                    alignItems: 'flex-start',
+                                    gap: '8px'
+                                }}>
+                                    {testProxyResult.success ? 
+                                        <Check size={16} style={{flexShrink: 0, marginTop: '1px'}} /> : 
+                                        <Info size={16} style={{flexShrink: 0, marginTop: '1px'}} />
+                                    }
+                                    <span style={{wordBreak: 'break-all', lineHeight: '1.4'}}>{testProxyResult.message}</span>
+                                </div>
+                            )}
+                        </div>
+
+                        <div className="settings-info-box" style={{ marginTop: '16px' }}>
+                            <Info size={16} />
+                            <span>{t('settings.proxy.note')}</span>
+                        </div>
+
+                        <div className="settings-card-actions">
+                            <button
+                                className="settings-btn-secondary"
+                                onClick={handleResetProxy}
+                                disabled={savingProxy || testingProxy || newProxy === proxy}
+                            >
+                                <RotateCcw size={16} />
+                                {t('settings.buttons.reset')}
+                            </button>
+                            <button
+                                className="settings-btn-primary"
+                                onClick={handleSaveProxy}
+                                disabled={savingProxy || testingProxy || newProxy === proxy}
+                            >
+                                {savingProxy ? <Loader2 className="spin" size={16} /> : <Check size={16} />}
+                                {savingProxy ? t('settings.buttons.saving') : t('settings.buttons.save')}
                             </button>
                         </div>
                     </div>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -448,7 +448,9 @@
       "caskAppDirReset": "Cask app directory reset to current value.",
       "customCaskOptsUpdated": "Custom cask options updated successfully!",
       "customOutdatedArgsUpdated": "Custom outdated arguments updated successfully!",
-      "adminUsernameUpdated": "Admin username updated successfully!"
+      "adminUsernameUpdated": "Admin username updated successfully!",
+      "proxyUpdated": "Proxy settings updated successfully!",
+      "proxyTestSuccess": "Proxy connection test successful!"
     },
     "errors": {
       "failedToGetPath": "Failed to get current brew path.",
@@ -461,7 +463,11 @@
       "failedToSelectDirectory": "Failed to select directory.",
       "failedToSetCustomCaskOpts": "Failed to set custom cask options. Please check your input.",
       "failedToSetCustomOutdatedArgs": "Failed to set custom outdated arguments. Please check your input.",
-      "failedToSetAdminUsername": "Failed to update admin username"
+      "failedToSetAdminUsername": "Failed to update admin username",
+      "failedToSetProxy": "Failed to set proxy connection. Please check your input.",
+      "emptyTestUrl": "Please enter a test URL.",
+      "emptyProxyForTest": "Please enter a proxy URL to test.",
+      "proxyTestFailed": "Proxy connection test failed."
     },
     "mirrorSource": {
       "title": "Homebrew Mirror Source",
@@ -514,6 +520,18 @@
       "placeholder": "Enter admin username",
       "currentUser": "Current user",
       "info": "This username will be used when Homebrew operations require administrator privileges. Leave empty to use your current user account."
+    },
+    "proxy": {
+      "title": "Proxy Settings",
+      "none": "None",
+      "description": "Configure an HTTP proxy for Homebrew. Supports username and password (e.g. http://user:pass@127.0.0.1:7890).",
+      "currentProxy": "Current Proxy",
+      "placeholder": "http://127.0.0.1:7890",
+      "note": "A restart might be required for some changes to take effect fully, but most brew commands will pick this up immediately.",
+      "testConnection": "Test Connection",
+      "testUrlPlaceholder": "https://google.com or https://brew.sh",
+      "testButton": "Test",
+      "testing": "Testing..."
     },
     "advancedOptions": {
       "title": "Advanced Options",

--- a/frontend/src/i18n/locales/zhCN.json
+++ b/frontend/src/i18n/locales/zhCN.json
@@ -448,7 +448,9 @@
       "caskAppDirReset": "Cask 应用程序目录设置重置为当前值。",
       "customCaskOptsUpdated": "自定义 Cask 选项更新成功！",
       "customOutdatedArgsUpdated": "自定义 outdated 参数更新成功！",
-      "adminUsernameUpdated": "Admin username updated successfully!"
+      "adminUsernameUpdated": "Admin username updated successfully!",
+      "proxyUpdated": "代理设置更新成功！",
+      "proxyTestSuccess": "代理连接测试成功！"
     },
     "errors": {
       "failedToGetPath": "无法获取当前 brew 的路径。",
@@ -461,7 +463,11 @@
       "failedToSelectDirectory": "选择目录失败。",
       "failedToSetCustomCaskOpts": "设置自定义 Cask 选项失败。请检查您的输入。",
       "failedToSetCustomOutdatedArgs": "设置自定义 outdated 参数失败。请检查您的输入。",
-      "failedToSetAdminUsername": "更新管理员用户名失败"
+      "failedToSetAdminUsername": "更新管理员用户名失败",
+      "failedToSetProxy": "代理设置失败，请检查输入。",
+      "emptyTestUrl": "请输入用于测试的目标 URL。",
+      "emptyProxyForTest": "请输入要测试的代理地址。",
+      "proxyTestFailed": "代理连接测试失败。"
     },
     "mirrorSource": {
       "title": "Homebrew 镜像源",
@@ -514,6 +520,18 @@
       "placeholder": "输入管理员用户名",
       "currentUser": "当前用户",
       "info": "当 Homebrew 操作需要管理员权限时，将使用此用户名。留空则使用您当前的用户账户。"
+    },
+    "proxy": {
+      "title": "代理设置",
+      "none": "无代理",
+      "description": "为软件及其调用的所有网络流量配置全局代理，支持包含用户名和密码格式（示例：http://user:pass@127.0.0.1:7890）。",
+      "currentProxy": "配置代理",
+      "placeholder": "例如：http://127.0.0.1:7890",
+      "note": "大部分网络请求将会立即自动应用该代理设置，极个别操作可能需要重启客户端生效。",
+      "testConnection": "连通性测试",
+      "testUrlPlaceholder": "测试目标 URL（例：https://brew.sh）",
+      "testButton": "一键测试",
+      "testing": "测试中..."
     },
     "advancedOptions": {
       "title": "高级选项",

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -78,6 +78,8 @@ export function GetMirrorSource():Promise<Record<string, string>>;
 
 export function GetOutdatedFlag():Promise<string>;
 
+export function GetProxy():Promise<string>;
+
 export function GetSessionLogs():Promise<string>;
 
 export function GetStartupData():Promise<brew.StartupData>;
@@ -132,7 +134,11 @@ export function SetMirrorSource(arg1:string,arg2:string):Promise<void>;
 
 export function SetOutdatedFlag(arg1:string):Promise<void>;
 
+export function SetProxy(arg1:string):Promise<void>;
+
 export function TapBrewRepository(arg1:string):Promise<string>;
+
+export function TestProxyConnection(arg1:string,arg2:string):Promise<string>;
 
 export function UntapBrewRepository(arg1:string):Promise<string>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -150,6 +150,10 @@ export function GetOutdatedFlag() {
   return window['go']['main']['App']['GetOutdatedFlag']();
 }
 
+export function GetProxy() {
+  return window['go']['main']['App']['GetProxy']();
+}
+
 export function GetSessionLogs() {
   return window['go']['main']['App']['GetSessionLogs']();
 }
@@ -258,8 +262,16 @@ export function SetOutdatedFlag(arg1) {
   return window['go']['main']['App']['SetOutdatedFlag'](arg1);
 }
 
+export function SetProxy(arg1) {
+  return window['go']['main']['App']['SetProxy'](arg1);
+}
+
 export function TapBrewRepository(arg1) {
   return window['go']['main']['App']['TapBrewRepository'](arg1);
+}
+
+export function TestProxyConnection(arg1, arg2) {
+  return window['go']['main']['App']['TestProxyConnection'](arg1, arg2);
 }
 
 export function UntapBrewRepository(arg1) {


### PR DESCRIPTION
## Overview
This Pull Request introduces global HTTP/HTTPS proxy support for WailBrew, allowing all underlying Homebrew commands and network requests to route through a user-defined proxy. It also includes an integrated UI to configure the proxy and test its connectivity interactively.

## Key Changes
- **Backend Configuration**: 
  - Added a new Proxy field to the application configuration context in `loadsave.go`.
  - Injected proxy environment variables into the Homebrew command executor inside `app.go`. This natively supports proxies with authentication schemas.
  - Implemented a new exported method testing the proxy connection that validates the configuration by performing an HTTP GET request to a user-specified target URL.

- **Frontend Settings**:
  - Implemented a new Proxy Settings card within the Settings view component.
  - Users can now input their proxy address and manage its state.
  - Added a Test Connection sub-panel where users can verify the proxy setup against a customizable target URL with visual success or error feedback.

- **Internationalization**:
  - Added comprehensive translation keys and localized texts for the new proxy feature in the English and Chinese localization JSON files.

## Testing Steps
1. Navigate to the Settings page and expand the new Proxy Settings card.
2. Enter a valid proxy address.
3. Specify a target URL and click the test button to receive immediate connectivity feedback.
4. Verify that running subsequent operations successfully routes traffic through the configured proxy.