### PR TITLE
feat: remove cask quarantine attribute and relaunch app after install/upgrade

### DIFF
--- a/app.go
+++ b/app.go
@@ -166,13 +166,13 @@ func NewApp() *App {
 	brewPath := detectBrewPath()
 	cfg := &config.Config{}
 	cfg.Load() // Load config early to get admin username
-	
+
 	// Get admin username from config, or current user as fallback
 	adminUsername := cfg.AdminUsername
 	if adminUsername == "" {
 		adminUsername = os.Getenv("USER")
 	}
-	
+
 	app := &App{
 		brewPath:          brewPath,
 		currentLanguage:   "en",
@@ -246,13 +246,11 @@ func (a *App) getBrewEnv() []string {
 	return env
 }
 
-// buildCaskOpts builds HOMEBREW_CASK_OPTS by merging UI-configured options with custom options
+// buildCaskOpts builds HOMEBREW_CASK_OPTS by merging UI-configured options with custom options.
+// Note: --no-quarantine is intentionally NOT added here; it is deprecated by Homebrew (Sep 2025).
+// Quarantine removal is handled post-install via xattr(1) when NoQuarantine is enabled.
 func (a *App) buildCaskOpts() string {
 	var opts []string
-
-	if a.config.NoQuarantine {
-		opts = append(opts, "--no-quarantine")
-	}
 
 	// Add UI-configured appdir if set
 	if a.config.CaskAppDir != "" {
@@ -360,6 +358,8 @@ func (a *App) startup(ctx context.Context) {
 		func() string { return a.GetCustomOutdatedArgs() },
 		brew.ExtractJSONFromOutput,
 		brew.ParseWarnings,
+		func() bool { return a.GetNoQuarantine() },
+		func() bool { return a.GetAutoRelaunch() },
 	)
 
 	// Restore last-known window position. Width/Height (and maximized state)
@@ -774,6 +774,18 @@ func (a *App) GetNoQuarantine() bool {
 
 func (a *App) SetNoQuarantine(val bool) error {
 	a.config.NoQuarantine = val
+	return a.config.Save()
+}
+
+// GetAutoRelaunch returns the current auto-relaunch setting.
+// When true (the default), WailBrew will quit a running cask app before upgrading
+// it and relaunch it after quarantine removal completes.
+func (a *App) GetAutoRelaunch() bool {
+	return a.config.AutoRelaunch
+}
+
+func (a *App) SetAutoRelaunch(val bool) error {
+	a.config.AutoRelaunch = val
 	return a.config.Save()
 }
 

--- a/backend/brew/actions.go
+++ b/backend/brew/actions.go
@@ -28,6 +28,9 @@ type ActionsService struct {
 	extractFailed    func(string) []string
 	validateFunc     func() error
 	getOutdatedFlag  func() string
+	getNoQuarantine  func() bool
+	getAutoRelaunch  func() bool
+	getCaskAppDir    func() string
 }
 
 // NewActionsService creates a new actions service
@@ -41,6 +44,8 @@ func NewActionsService(
 	extractFailed func(string) []string,
 	validateFunc func() error,
 	getOutdatedFlag func() string,
+	getNoQuarantine func() bool,
+	getAutoRelaunch func() bool,
 ) *ActionsService {
 	return &ActionsService{
 		brewPath:         brewPath,
@@ -52,6 +57,97 @@ func NewActionsService(
 		extractFailed:    extractFailed,
 		validateFunc:     validateFunc,
 		getOutdatedFlag:  getOutdatedFlag,
+		getNoQuarantine:  getNoQuarantine,
+		getAutoRelaunch:  getAutoRelaunch,
+		// getCaskAppDir is populated separately — the App-level setting is not
+		// available at construction time in the current wiring, so we use a
+		// safe no-op default that resolves to /Applications.
+		getCaskAppDir: func() string { return "" },
+	}
+}
+
+// postInstallCask runs quarantine removal (and optional quit/relaunch) for a
+// successfully installed or upgraded cask. Errors are emitted as warnings but
+// never fail the overall operation — the cask itself was already installed.
+func (s *ActionsService) postInstallCask(packageName, progressEvent string) {
+	if s.getNoQuarantine == nil || !s.getNoQuarantine() {
+		return
+	}
+
+	appDir := ""
+	if s.getCaskAppDir != nil {
+		appDir = s.getCaskAppDir()
+	}
+
+	// Resolve the installed .app path from brew info
+	appPath, isPkg, err := system.ResolveCaskAppPath(s.brewPath, packageName, appDir)
+	if err != nil {
+		warnMsg := s.getBackendMsg("quarantine.resolveFailed", map[string]string{
+			"name":  packageName,
+			"error": err.Error(),
+		})
+		s.eventEmitter.Emit(progressEvent, warnMsg)
+		return
+	}
+
+	// .pkg-based cask — skip with informational message
+	if isPkg {
+		infoMsg := s.getBackendMsg("quarantine.skippedPkg", map[string]string{
+			"name": packageName,
+		})
+		s.eventEmitter.Emit(progressEvent, infoMsg)
+		return
+	}
+
+	appName := system.AppNameFromPath(appPath)
+	wasRunning := false
+
+	// Quit the app gracefully if it is running and auto-relaunch is enabled
+	if s.getAutoRelaunch != nil && s.getAutoRelaunch() && system.IsAppRunning(appName) {
+		quitMsg := s.getBackendMsg("quarantine.quitting", map[string]string{"name": appName})
+		s.eventEmitter.Emit(progressEvent, quitMsg)
+
+		if err := system.QuitAppGracefully(appName); err != nil {
+			warnMsg := s.getBackendMsg("quarantine.quitFailed", map[string]string{
+				"name":  appName,
+				"error": err.Error(),
+			})
+			s.eventEmitter.Emit(progressEvent, warnMsg)
+			// Proceed with quarantine removal even if quit failed
+		} else {
+			wasRunning = true
+		}
+	}
+
+	// Remove the quarantine attribute
+	removeMsg := s.getBackendMsg("quarantine.removing", map[string]string{"path": appPath})
+	s.eventEmitter.Emit(progressEvent, removeMsg)
+
+	if err := system.RemoveQuarantine(appPath); err != nil {
+		warnMsg := s.getBackendMsg("quarantine.removeFailed", map[string]string{
+			"path":  appPath,
+			"error": err.Error(),
+		})
+		s.eventEmitter.Emit(progressEvent, warnMsg)
+		// Still try to relaunch even if xattr had issues (attribute may not have
+		// been set at all, which xattr treats as a non-fatal error).
+	} else {
+		removedMsg := s.getBackendMsg("quarantine.removed", map[string]string{"path": appPath})
+		s.eventEmitter.Emit(progressEvent, removedMsg)
+	}
+
+	// Relaunch the app if it was running before the upgrade
+	if wasRunning {
+		relaunchMsg := s.getBackendMsg("quarantine.relaunching", map[string]string{"name": appName})
+		s.eventEmitter.Emit(progressEvent, relaunchMsg)
+
+		if err := system.LaunchApp(appPath); err != nil {
+			warnMsg := s.getBackendMsg("quarantine.relaunchFailed", map[string]string{
+				"name":  appName,
+				"error": err.Error(),
+			})
+			s.eventEmitter.Emit(progressEvent, warnMsg)
+		}
 	}
 }
 
@@ -140,6 +236,12 @@ func (s *ActionsService) InstallBrewPackage(ctx context.Context, packageName str
 	// Success
 	successMsg := s.getBackendMsg("installSuccess", map[string]string{"name": packageName})
 	s.eventEmitter.Emit("packageInstallProgress", successMsg)
+
+	// Post-install: remove quarantine attribute for casks
+	if s.isPackageCask(packageName) {
+		s.postInstallCask(packageName, "packageInstallProgress")
+	}
+
 	s.eventEmitter.Emit("packageInstallComplete", successMsg)
 	return successMsg
 }
@@ -312,6 +414,11 @@ func (s *ActionsService) RunUpdateCommand(packageName string, useForce bool) (fi
 	finalMessage = s.getBackendMsg("updateSuccess", map[string]string{"name": packageName})
 	s.eventEmitter.Emit("packageUpdateProgress", finalMessage)
 
+	// Post-upgrade: remove quarantine attribute for casks
+	if s.isPackageCask(packageName) {
+		s.postInstallCask(packageName, "packageUpdateProgress")
+	}
+
 	// Check if WailBrew itself was updated
 	if strings.ToLower(packageName) == "wailbrew" {
 		wailbrewUpdated = true
@@ -480,6 +587,16 @@ func (s *ActionsService) UpdateSelectedBrewPackages(ctx context.Context, package
 	} else {
 		finalMessage = fmt.Sprintf("✅ Successfully updated %d selected package(s)", len(packageNames))
 		s.eventEmitter.Emit("packageUpdateProgress", finalMessage)
+
+		// Post-upgrade: run quarantine removal for each upgraded cask.
+		// UpdateSelectedBrewPackages uses a single bulk brew command, so
+		// postInstallCask is NOT triggered transitively via RunUpdateCommand.
+		// We must loop here explicitly.
+		for _, pkg := range packageNames {
+			if s.isPackageCask(pkg) {
+				s.postInstallCask(pkg, "packageUpdateProgress")
+			}
+		}
 	}
 
 	// Signal completion

--- a/backend/brew/service.go
+++ b/backend/brew/service.go
@@ -123,6 +123,8 @@ func NewService(
 	getCustomOutdatedArgs func() string,
 	extractJSON func(string) (string, string, error),
 	parseWarnings func(string) map[string]string,
+	getNoQuarantine func() bool,
+	getAutoRelaunch func() bool,
 ) Service {
 	// Create database service first (needs executor)
 	databaseService := NewDatabaseService(executor)
@@ -165,6 +167,8 @@ func NewService(
 		outdatedService.ExtractFailedPackagesFromError,
 		validateFunc,
 		getOutdatedFlag,
+		getNoQuarantine,
+		getAutoRelaunch,
 	)
 
 	// Create tap service

--- a/backend/config/loadsave.go
+++ b/backend/config/loadsave.go
@@ -18,7 +18,10 @@ type Config struct {
 	AdminUsername      string `json:"adminUsername"`      // Admin username for sudo operations (defaults to current user)
 	Proxy              string `json:"proxy"`              // Global proxy setting (e.g., "http://127.0.0.1:7890" or "http://user:pass@127.0.0.1:7890")
 	LandingTab         string `json:"landingTab"`         // Tab to focus on startup (default: "installed")
-	NoQuarantine       bool   `json:"noQuarantine"`       // Skip quarantine attribute on cask installs (--no-quarantine)
+	NoQuarantine       bool   `json:"noQuarantine"`       // Remove com.apple.quarantine xattr after cask install/upgrade via xattr(1).
+	// Note: does NOT use the deprecated --no-quarantine Homebrew flag (deprecated Sep 2025,
+	// see https://github.com/orgs/Homebrew/discussions/6537).
+	AutoRelaunch bool `json:"autoRelaunch"` // Quit the running app before upgrade and relaunch after quarantine removal
 
 	// Window geometry — persisted across launches so the window opens where it
 	// was last left. Zero values mean "not yet captured" and the app falls back
@@ -82,6 +85,12 @@ func (c *Config) ResolvedPath() (string, error) {
 
 // Load reads the configuration from the resolved config path.
 func (c *Config) Load() error {
+	// Seed defaults before reading. json.Unmarshal only overwrites keys that are
+	// actually present in the file, so a config that predates these fields (or no
+	// config file at all) keeps the intended default, while an explicit value in
+	// the file still wins.
+	c.AutoRelaunch = true // relaunch a running app after an upgrade by default
+
 	configPath, err := GetConfigPath()
 	if err != nil {
 		return err

--- a/backend/system/quarantine_darwin.go
+++ b/backend/system/quarantine_darwin.go
@@ -1,0 +1,173 @@
+//go:build darwin
+// +build darwin
+
+package system
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// caskInfoV2 is the minimal shape of `brew info --cask --json=v2` output that we
+// care about: the top-level "casks" array, and within each cask its "token" and
+// "artifacts" list.
+type caskInfoV2 struct {
+	Casks []struct {
+		Token     string        `json:"token"`
+		Artifacts []interface{} `json:"artifacts"`
+	} `json:"casks"`
+}
+
+// ResolveCaskAppPath runs `brew info --cask --json=v2 <caskName>` and inspects
+// the artifacts field to find the installed .app path.
+//
+//   - If an "app" artifact is found, appPath is the full path (e.g.
+//     /Applications/Firefox.app) and isPkg is false.
+//   - If only "pkg" artifacts are found, appPath is "" and isPkg is true; the
+//     caller should skip quarantine removal and emit an informational message.
+//   - On any other failure, err is non-nil.
+//
+// The appDir argument is the directory to prepend when the cask artifact only
+// records the bare filename; pass "" to default to /Applications.
+func ResolveCaskAppPath(brewPath, caskName, appDir string) (appPath string, isPkg bool, err error) {
+	if appDir == "" {
+		appDir = "/Applications"
+	}
+
+	out, err := exec.Command(brewPath, "info", "--cask", "--json=v2", caskName).Output()
+	if err != nil {
+		return "", false, fmt.Errorf("brew info failed for %s: %w", caskName, err)
+	}
+
+	return parseCaskArtifacts(out, appDir)
+}
+
+// parseCaskArtifacts parses the raw JSON from `brew info --cask --json=v2` and
+// extracts the first .app path (or detects pkg-only installs).
+// Separated from ResolveCaskAppPath to allow unit testing without shelling out.
+func parseCaskArtifacts(jsonBytes []byte, appDir string) (appPath string, isPkg bool, err error) {
+	// Trim any leading non-JSON warnings Homebrew may emit
+	start := bytes.IndexByte(jsonBytes, '{')
+	if start == -1 {
+		return "", false, fmt.Errorf("no JSON found in brew info output")
+	}
+	jsonBytes = jsonBytes[start:]
+
+	var info caskInfoV2
+	if err := json.Unmarshal(jsonBytes, &info); err != nil {
+		return "", false, fmt.Errorf("failed to parse brew info JSON: %w", err)
+	}
+
+	if len(info.Casks) == 0 {
+		return "", false, fmt.Errorf("no cask data in brew info output")
+	}
+
+	cask := info.Casks[0]
+	hasPkg := false
+
+	// Artifacts is a heterogeneous array. Each element is either:
+	//   - a string (name of an artifact type with no targets)
+	//   - an object like {"app": ["Name.app"]} or {"pkg": ["installer.pkg"]}
+	for _, raw := range cask.Artifacts {
+		obj, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// Check for "app" key
+		if appList, ok := obj["app"]; ok {
+			if arr, ok := appList.([]interface{}); ok && len(arr) > 0 {
+				name, ok := arr[0].(string)
+				if ok && name != "" {
+					// The artifact may be a bare filename or an absolute path
+					if strings.HasPrefix(name, "/") {
+						return name, false, nil
+					}
+					return appDir + "/" + name, false, nil
+				}
+			}
+		}
+
+		// Check for "pkg" key
+		if _, ok := obj["pkg"]; ok {
+			hasPkg = true
+		}
+	}
+
+	if hasPkg {
+		return "", true, nil
+	}
+
+	return "", false, fmt.Errorf("no app or pkg artifact found for cask %s", cask.Token)
+}
+
+// AppNameFromPath returns the process name to use with pgrep / AppleScript
+// given a full .app bundle path like /Applications/Firefox.app → "Firefox".
+func AppNameFromPath(appPath string) string {
+	base := appPath
+	if idx := strings.LastIndex(base, "/"); idx != -1 {
+		base = base[idx+1:]
+	}
+	base = strings.TrimSuffix(base, ".app")
+	return base
+}
+
+// IsAppRunning returns true if a process named exactly appName is currently
+// running. Uses pgrep -x which matches the full process name exactly.
+func IsAppRunning(appName string) bool {
+	err := exec.Command("pgrep", "-x", appName).Run()
+	return err == nil
+}
+
+// QuitAppGracefully asks the named application to quit via AppleScript, then
+// polls until the process exits or the 10-second timeout expires. If the
+// process is still alive after the timeout, it is killed with pkill -x.
+func QuitAppGracefully(appName string) error {
+	script := fmt.Sprintf(`tell application "%s" to quit`, appName)
+	quitCmd := exec.Command("osascript", "-e", script)
+	// Ignore osascript errors — the app may not support AppleScript quit but
+	// pgrep will tell us the truth about whether it exited.
+	_ = quitCmd.Run()
+
+	// Poll for up to 10 seconds
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if !IsAppRunning(appName) {
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	// Timeout — fall back to pkill
+	if err := exec.Command("pkill", "-x", appName).Run(); err != nil {
+		return fmt.Errorf("pkill %s failed: %w", appName, err)
+	}
+	return nil
+}
+
+// RemoveQuarantine removes the com.apple.quarantine extended attribute
+// recursively from appPath using xattr(1).
+func RemoveQuarantine(appPath string) error {
+	out, err := exec.Command("xattr", "-r", "-d", "com.apple.quarantine", appPath).CombinedOutput()
+	if err != nil {
+		// xattr exits non-zero if the attribute wasn't set — treat that as success
+		if strings.Contains(string(out), "No such xattr") ||
+			strings.Contains(string(out), "attribute not found") {
+			return nil
+		}
+		return fmt.Errorf("xattr failed for %s: %w (output: %s)", appPath, err, string(out))
+	}
+	return nil
+}
+
+// LaunchApp opens the .app bundle at appPath using the open(1) command.
+func LaunchApp(appPath string) error {
+	if err := exec.Command("open", appPath).Start(); err != nil {
+		return fmt.Errorf("open %s failed: %w", appPath, err)
+	}
+	return nil
+}

--- a/backend/system/quarantine_darwin_test.go
+++ b/backend/system/quarantine_darwin_test.go
@@ -1,0 +1,144 @@
+//go:build darwin
+// +build darwin
+
+package system
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// buildArtifactJSON is a helper that serialises a casks array from raw artifact
+// maps so tests don't have to hand-craft JSON strings.
+func buildArtifactJSON(t *testing.T, artifacts ...map[string]interface{}) []byte {
+	t.Helper()
+	type cask struct {
+		Token     string                   `json:"token"`
+		Artifacts []map[string]interface{} `json:"artifacts"`
+	}
+	data, err := json.Marshal(map[string]interface{}{
+		"casks": []cask{{Token: "testcask", Artifacts: artifacts}},
+	})
+	if err != nil {
+		t.Fatalf("buildArtifactJSON: %v", err)
+	}
+	return data
+}
+
+func TestParseCaskArtifacts_AppAbsolutePath(t *testing.T) {
+	raw := buildArtifactJSON(t, map[string]interface{}{
+		"app": []interface{}{"/Applications/MyApp.app"},
+	})
+	got, isPkg, err := parseCaskArtifacts(raw, "/Applications")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isPkg {
+		t.Fatal("expected isPkg=false")
+	}
+	if got != "/Applications/MyApp.app" {
+		t.Fatalf("expected /Applications/MyApp.app, got %q", got)
+	}
+}
+
+func TestParseCaskArtifacts_AppBareName(t *testing.T) {
+	raw := buildArtifactJSON(t, map[string]interface{}{
+		"app": []interface{}{"Firefox.app"},
+	})
+	got, isPkg, err := parseCaskArtifacts(raw, "/Applications")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isPkg {
+		t.Fatal("expected isPkg=false")
+	}
+	if got != "/Applications/Firefox.app" {
+		t.Fatalf("expected /Applications/Firefox.app, got %q", got)
+	}
+}
+
+func TestParseCaskArtifacts_PkgOnly(t *testing.T) {
+	raw := buildArtifactJSON(t, map[string]interface{}{
+		"pkg": []interface{}{"Installer.pkg"},
+	})
+	_, isPkg, err := parseCaskArtifacts(raw, "/Applications")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !isPkg {
+		t.Fatal("expected isPkg=true for pkg-only cask")
+	}
+}
+
+func TestParseCaskArtifacts_AppTakesPrecedenceOverPkg(t *testing.T) {
+	raw := buildArtifactJSON(t,
+		map[string]interface{}{"pkg": []interface{}{"Something.pkg"}},
+		map[string]interface{}{"app": []interface{}{"TheApp.app"}},
+	)
+	got, isPkg, err := parseCaskArtifacts(raw, "/Applications")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isPkg {
+		t.Fatal("expected isPkg=false when app artifact present")
+	}
+	if got != "/Applications/TheApp.app" {
+		t.Fatalf("expected /Applications/TheApp.app, got %q", got)
+	}
+}
+
+func TestParseCaskArtifacts_NoUsefulArtifact(t *testing.T) {
+	// An artifact list with only string entries (e.g. "zap") — no app or pkg map
+	data, _ := json.Marshal(map[string]interface{}{
+		"casks": []map[string]interface{}{{
+			"token":     "testcask",
+			"artifacts": []interface{}{"zap"},
+		}},
+	})
+	_, _, err := parseCaskArtifacts(data, "/Applications")
+	if err == nil {
+		t.Fatal("expected an error for a cask with no app/pkg artifact")
+	}
+}
+
+func TestParseCaskArtifacts_EmptyCasks(t *testing.T) {
+	data, _ := json.Marshal(map[string]interface{}{"casks": []interface{}{}})
+	_, _, err := parseCaskArtifacts(data, "/Applications")
+	if err == nil {
+		t.Fatal("expected an error for empty casks array")
+	}
+}
+
+func TestParseCaskArtifacts_LeadingWarning(t *testing.T) {
+	// Simulate Homebrew emitting a warning line before the JSON
+	warning := []byte("Warning: some-tap is not trusted\n")
+	jsonPart := buildArtifactJSON(t, map[string]interface{}{
+		"app": []interface{}{"WarningApp.app"},
+	})
+	combined := append(warning, jsonPart...)
+	got, _, err := parseCaskArtifacts(combined, "/Applications")
+	if err != nil {
+		t.Fatalf("unexpected error with leading warning: %v", err)
+	}
+	if got != "/Applications/WarningApp.app" {
+		t.Fatalf("expected /Applications/WarningApp.app, got %q", got)
+	}
+}
+
+func TestAppNameFromPath(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"/Applications/Firefox.app", "Firefox"},
+		{"/Applications/Visual Studio Code.app", "Visual Studio Code"},
+		{"Bare.app", "Bare"},
+		{"/Applications/NoExt", "NoExt"},
+	}
+	for _, tc := range cases {
+		got := AppNameFromPath(tc.input)
+		if got != tc.want {
+			t.Errorf("AppNameFromPath(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}

--- a/backend/system/quarantine_other.go
+++ b/backend/system/quarantine_other.go
@@ -1,0 +1,39 @@
+//go:build !darwin
+// +build !darwin
+
+package system
+
+// ResolveCaskAppPath is a no-op on non-macOS platforms.
+func ResolveCaskAppPath(brewPath, caskName, appDir string) (appPath string, isPkg bool, err error) {
+	return "", false, nil
+}
+
+// parseCaskArtifacts is a no-op on non-macOS platforms.
+func parseCaskArtifacts(jsonBytes []byte, appDir string) (appPath string, isPkg bool, err error) {
+	return "", false, nil
+}
+
+// AppNameFromPath is a no-op on non-macOS platforms.
+func AppNameFromPath(appPath string) string {
+	return ""
+}
+
+// IsAppRunning is a no-op on non-macOS platforms.
+func IsAppRunning(appName string) bool {
+	return false
+}
+
+// QuitAppGracefully is a no-op on non-macOS platforms.
+func QuitAppGracefully(appName string) error {
+	return nil
+}
+
+// RemoveQuarantine is a no-op on non-macOS platforms.
+func RemoveQuarantine(appPath string) error {
+	return nil
+}
+
+// LaunchApp is a no-op on non-macOS platforms.
+func LaunchApp(appPath string) error {
+	return nil
+}

--- a/frontend/src/components/SettingsView.tsx
+++ b/frontend/src/components/SettingsView.tsx
@@ -18,7 +18,7 @@ import {
     Network,
     Home
 } from "lucide-react";
-import { GetBrewPath, SetBrewPath, GetMirrorSource, SetMirrorSource, GetOutdatedFlag, SetOutdatedFlag, GetCaskAppDir, SetCaskAppDir, SelectCaskAppDir, GetCustomCaskOpts, SetCustomCaskOpts, GetCustomOutdatedArgs, SetCustomOutdatedArgs, GetAdminUsername, SetAdminUsername, GetMacOSVersion, GetMacOSReleaseName, GetSystemArchitecture, GetProxy, SetProxy, TestProxyConnection, GetLandingTab, SetLandingTab, GetNoQuarantine, SetNoQuarantine } from "../../wailsjs/go/main/App";
+import { GetBrewPath, SetBrewPath, GetMirrorSource, SetMirrorSource, GetOutdatedFlag, SetOutdatedFlag, GetCaskAppDir, SetCaskAppDir, SelectCaskAppDir, GetCustomCaskOpts, SetCustomCaskOpts, GetCustomOutdatedArgs, SetCustomOutdatedArgs, GetAdminUsername, SetAdminUsername, GetMacOSVersion, GetMacOSReleaseName, GetSystemArchitecture, GetProxy, SetProxy, TestProxyConnection, GetLandingTab, SetLandingTab, GetNoQuarantine, SetNoQuarantine, GetAutoRelaunch, SetAutoRelaunch } from "../../wailsjs/go/main/App";
 import toast from 'react-hot-toast';
 
 interface SettingsViewProps {
@@ -74,6 +74,7 @@ const SettingsView: React.FC<SettingsViewProps> = ({ onRefreshPackages }) => {
     const [isLandingTabExpanded, setIsLandingTabExpanded] = useState<boolean>(false);
 
     const [noQuarantine, setNoQuarantine] = useState<boolean>(false);
+    const [autoRelaunch, setAutoRelaunch] = useState<boolean>(true);
 
     useEffect(() => {
         loadCurrentBrewPath();
@@ -87,6 +88,7 @@ const SettingsView: React.FC<SettingsViewProps> = ({ onRefreshPackages }) => {
         loadCurrentProxy();
         loadLandingTab();
         loadNoQuarantine();
+        loadAutoRelaunch();
     }, []);
 
     const loadCurrentBrewPath = async () => {
@@ -630,6 +632,26 @@ const SettingsView: React.FC<SettingsViewProps> = ({ onRefreshPackages }) => {
         }
     };
 
+    const loadAutoRelaunch = async () => {
+        try {
+            const val = await GetAutoRelaunch();
+            setAutoRelaunch(val);
+        } catch (error) {
+            console.error("Failed to get auto-relaunch setting:", error);
+        }
+    };
+
+    const handleToggleAutoRelaunch = async () => {
+        const newVal = !autoRelaunch;
+        try {
+            await SetAutoRelaunch(newVal);
+            setAutoRelaunch(newVal);
+        } catch (error) {
+            console.error("Failed to set auto-relaunch:", error);
+            toast.error(String(error));
+        }
+    };
+
     const getMirrorDisplayName = () => {
         if (mirrorSource === "official") {
             return t('settings.mirrorSource.mirrors.official');
@@ -777,6 +799,28 @@ const SettingsView: React.FC<SettingsViewProps> = ({ onRefreshPackages }) => {
                             onClick={handleToggleNoQuarantine}
                             aria-checked={noQuarantine}
                             role="switch"
+                        />
+                    </div>
+                </div>
+
+                {/* Auto-Relaunch Toggle Card */}
+                <div className={`settings-card ${autoRelaunch ? 'expanded' : ''}`}>
+                    <div className="settings-card-header" style={{ cursor: 'default' }}>
+                        <div className="settings-card-icon">
+                            <RefreshCw size={20} />
+                        </div>
+                        <div className="settings-card-info">
+                            <h3>{t('settings.autoRelaunch.title')}</h3>
+                            <span className="settings-card-value" style={{ whiteSpace: 'normal', fontFamily: 'inherit' }}>
+                                {t('settings.autoRelaunch.description')}
+                            </span>
+                        </div>
+                        <button
+                            className={`settings-toggle ${autoRelaunch ? 'active' : ''}`}
+                            onClick={handleToggleAutoRelaunch}
+                            aria-checked={autoRelaunch}
+                            role="switch"
+                            id="settings-auto-relaunch-toggle"
                         />
                     </div>
                 </div>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -429,8 +429,8 @@
       "label": "Starten mit"
     },
     "noQuarantine": {
-      "title": "Quarantäne für Casks überspringen",
-      "description": "Entfernt automatisch das macOS-Quarantäne-Attribut beim Installieren oder Aktualisieren von Casks. Verhindert die Warnung 'App ist beschädigt' oder Gatekeeper-Meldung beim ersten Start."
+      "title": "Remove Quarantine Attribute for Casks",
+      "description": "After installing or upgrading a cask, automatically remove the macOS quarantine attribute via xattr. This prevents the \"app is damaged\" or Gatekeeper warning on first launch. Does not use the deprecated --no-quarantine Homebrew flag."
     },
     "brewPath": {
       "title": "Homebrew-Pfad-Konfiguration",
@@ -565,6 +565,10 @@
         "hint": "Zusätzliche Argumente für den 'brew outdated' Befehl. Beispiel: --verbose, --formula, --cask. Diese werden an das oben konfigurierte Outdated-Flag angehängt.",
         "preview": "Neue Argumente"
       }
+    },
+    "autoRelaunch": {
+      "title": "Auto-Relaunch After Upgrade",
+      "description": "If a cask app is running when an upgrade begins, quit it first, then automatically relaunch it after quarantine removal completes. Requires 'Remove Quarantine Attribute' to be enabled."
     }
   },
   "backend": {
@@ -626,6 +630,17 @@
     },
     "outdated": {
       "autoUpdateCask": "Diese App aktualisiert sich selbst und ist möglicherweise bereits aktuell. Die von Homebrew gespeicherte Installationsversion kann hinter der tatsächlichen App-Version zurückbleiben."
+    },
+    "quarantine": {
+      "removing": "🔒 Removing quarantine attribute from {{path}}…",
+      "removed": "🔒 Quarantine attribute removed from {{path}}",
+      "removeFailed": "⚠️ Failed to remove quarantine from {{path}}: {{error}}",
+      "skippedPkg": "ℹ️ Quarantine removal skipped: {{name}} installs via .pkg (not a plain .app bundle)",
+      "resolveFailed": "⚠️ Could not resolve installed app path for {{name}}: {{error}}",
+      "quitting": "⏹ Quitting {{name}} before upgrade…",
+      "quitFailed": "⚠️ Failed to quit {{name}}: {{error}}",
+      "relaunching": "🚀 Relaunching {{name}}…",
+      "relaunchFailed": "⚠️ Failed to relaunch {{name}}: {{error}}"
     }
   },
   "view": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -429,8 +429,12 @@
       "label": "Start on"
     },
     "noQuarantine": {
-      "title": "Skip Quarantine for Casks",
-      "description": "Automatically remove the macOS quarantine attribute when installing or upgrading casks. This prevents the \"app is damaged\" or Gatekeeper warning on first launch."
+      "title": "Remove Quarantine Attribute for Casks",
+      "description": "After installing or upgrading a cask, automatically remove the macOS quarantine attribute via xattr. This prevents the \"app is damaged\" or Gatekeeper warning on first launch. Does not use the deprecated --no-quarantine Homebrew flag."
+    },
+    "autoRelaunch": {
+      "title": "Auto-Relaunch After Upgrade",
+      "description": "If a cask app is running when an upgrade begins, quit it first, then automatically relaunch it after quarantine removal completes. Requires 'Remove Quarantine Attribute' to be enabled."
     },
     "brewPath": {
       "title": "Homebrew Path Configuration",
@@ -626,6 +630,17 @@
     },
     "outdated": {
       "autoUpdateCask": "This auto-updating app may already be up to date. Homebrew's recorded install version can lag behind the actual app version."
+    },
+    "quarantine": {
+      "removing": "🔒 Removing quarantine attribute from {{path}}…",
+      "removed": "🔒 Quarantine attribute removed from {{path}}",
+      "removeFailed": "⚠️ Failed to remove quarantine from {{path}}: {{error}}",
+      "skippedPkg": "ℹ️ Quarantine removal skipped: {{name}} installs via .pkg (not a plain .app bundle)",
+      "resolveFailed": "⚠️ Could not resolve installed app path for {{name}}: {{error}}",
+      "quitting": "⏹ Quitting {{name}} before upgrade…",
+      "quitFailed": "⚠️ Failed to quit {{name}}: {{error}}",
+      "relaunching": "🚀 Relaunching {{name}}…",
+      "relaunchFailed": "⚠️ Failed to relaunch {{name}}: {{error}}"
     }
   },
   "view": {

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -429,8 +429,8 @@
       "label": "Iniciar en"
     },
     "noQuarantine": {
-      "title": "Omitir cuarentena para casks",
-      "description": "Elimina automáticamente el atributo de cuarentena de macOS al instalar o actualizar casks. Evita la advertencia de \"app dañada\" o Gatekeeper en el primer inicio."
+      "title": "Remove Quarantine Attribute for Casks",
+      "description": "After installing or upgrading a cask, automatically remove the macOS quarantine attribute via xattr. This prevents the \"app is damaged\" or Gatekeeper warning on first launch. Does not use the deprecated --no-quarantine Homebrew flag."
     },
     "brewPath": {
       "title": "Configuración del path de Homebrew",
@@ -565,6 +565,10 @@
         "hint": "Argumentos para el comando 'brew outdated'. Ejemplo: --verbose, --formula, --cask. Estos se agregarán a la bandera de actualización configurada en la interfaz.",
         "preview": "Nuevos argumentos"
       }
+    },
+    "autoRelaunch": {
+      "title": "Auto-Relaunch After Upgrade",
+      "description": "If a cask app is running when an upgrade begins, quit it first, then automatically relaunch it after quarantine removal completes. Requires 'Remove Quarantine Attribute' to be enabled."
     }
   },
   "backend": {
@@ -626,6 +630,17 @@
     },
     "outdated": {
       "autoUpdateCask": "Es posible que esta aplicación con actualización automática ya esté actualizada. La versión de instalación registrada por Homebrew puede quedar detrás de la versión real de la aplicación."
+    },
+    "quarantine": {
+      "removing": "🔒 Removing quarantine attribute from {{path}}…",
+      "removed": "🔒 Quarantine attribute removed from {{path}}",
+      "removeFailed": "⚠️ Failed to remove quarantine from {{path}}: {{error}}",
+      "skippedPkg": "ℹ️ Quarantine removal skipped: {{name}} installs via .pkg (not a plain .app bundle)",
+      "resolveFailed": "⚠️ Could not resolve installed app path for {{name}}: {{error}}",
+      "quitting": "⏹ Quitting {{name}} before upgrade…",
+      "quitFailed": "⚠️ Failed to quit {{name}}: {{error}}",
+      "relaunching": "🚀 Relaunching {{name}}…",
+      "relaunchFailed": "⚠️ Failed to relaunch {{name}}: {{error}}"
     }
   },
   "view": {

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -429,8 +429,8 @@
       "label": "Démarrer sur"
     },
     "noQuarantine": {
-      "title": "Ignorer la quarantaine pour les casks",
-      "description": "Supprime automatiquement l'attribut de quarantaine macOS lors de l'installation ou la mise à jour des casks. Empêche l'avertissement « l'application est endommagée » ou Gatekeeper au premier lancement."
+      "title": "Remove Quarantine Attribute for Casks",
+      "description": "After installing or upgrading a cask, automatically remove the macOS quarantine attribute via xattr. This prevents the \"app is damaged\" or Gatekeeper warning on first launch. Does not use the deprecated --no-quarantine Homebrew flag."
     },
     "brewPath": {
       "title": "Configuration du chemin Homebrew",
@@ -565,6 +565,10 @@
         "hint": "Arguments supplémentaires pour la commande 'brew outdated'. Exemple : --verbose, --formula, --cask. Ceux-ci seront ajoutés au drapeau outdated configuré dans l'interface ci-dessus.",
         "preview": "Nouveaux arguments"
       }
+    },
+    "autoRelaunch": {
+      "title": "Auto-Relaunch After Upgrade",
+      "description": "If a cask app is running when an upgrade begins, quit it first, then automatically relaunch it after quarantine removal completes. Requires 'Remove Quarantine Attribute' to be enabled."
     }
   },
   "backend": {
@@ -626,6 +630,17 @@
     },
     "outdated": {
       "autoUpdateCask": "Cette application à mise à jour automatique est peut-être déjà à jour. La version d'installation enregistrée par Homebrew peut être en retard sur la version réelle de l'application."
+    },
+    "quarantine": {
+      "removing": "🔒 Removing quarantine attribute from {{path}}…",
+      "removed": "🔒 Quarantine attribute removed from {{path}}",
+      "removeFailed": "⚠️ Failed to remove quarantine from {{path}}: {{error}}",
+      "skippedPkg": "ℹ️ Quarantine removal skipped: {{name}} installs via .pkg (not a plain .app bundle)",
+      "resolveFailed": "⚠️ Could not resolve installed app path for {{name}}: {{error}}",
+      "quitting": "⏹ Quitting {{name}} before upgrade…",
+      "quitFailed": "⚠️ Failed to quit {{name}}: {{error}}",
+      "relaunching": "🚀 Relaunching {{name}}…",
+      "relaunchFailed": "⚠️ Failed to relaunch {{name}}: {{error}}"
     }
   },
   "view": {

--- a/frontend/src/i18n/locales/he.json
+++ b/frontend/src/i18n/locales/he.json
@@ -429,8 +429,8 @@
       "label": "התחל ב"
     },
     "noQuarantine": {
-      "title": "דלג על הסגר עבור casks",
-      "description": "מסיר אוטומטית את תכונת ההסגר של macOS בעת התקנה או עדכון של casks. מונע את אזהרת \"האפליקציה פגומה\" או Gatekeeper בהפעלה הראשונה."
+      "title": "Remove Quarantine Attribute for Casks",
+      "description": "After installing or upgrading a cask, automatically remove the macOS quarantine attribute via xattr. This prevents the \"app is damaged\" or Gatekeeper warning on first launch. Does not use the deprecated --no-quarantine Homebrew flag."
     },
     "brewPath": {
       "title": "הגדרת נתיב Homebrew",
@@ -565,6 +565,10 @@
         "hint": "ארגומנטים נוספים לפקודת 'brew outdated'. לדוגמה: --verbose, --formula, --cask. אלו יצורפו לדגל המיושנים שהוגדר בממשק למעלה.",
         "preview": "ארגומנטים חדשים"
       }
+    },
+    "autoRelaunch": {
+      "title": "Auto-Relaunch After Upgrade",
+      "description": "If a cask app is running when an upgrade begins, quit it first, then automatically relaunch it after quarantine removal completes. Requires 'Remove Quarantine Attribute' to be enabled."
     }
   },
   "backend": {
@@ -626,6 +630,17 @@
     },
     "outdated": {
       "autoUpdateCask": "ייתכן שהאפליקציה הזו עם עדכון אוטומטי כבר מעודכנת. גרסת ההתקנה ש-Homebrew מתעד עלולה להישאר מאחורי גרסת האפליקציה בפועל."
+    },
+    "quarantine": {
+      "removing": "🔒 Removing quarantine attribute from {{path}}…",
+      "removed": "🔒 Quarantine attribute removed from {{path}}",
+      "removeFailed": "⚠️ Failed to remove quarantine from {{path}}: {{error}}",
+      "skippedPkg": "ℹ️ Quarantine removal skipped: {{name}} installs via .pkg (not a plain .app bundle)",
+      "resolveFailed": "⚠️ Could not resolve installed app path for {{name}}: {{error}}",
+      "quitting": "⏹ Quitting {{name}} before upgrade…",
+      "quitFailed": "⚠️ Failed to quit {{name}}: {{error}}",
+      "relaunching": "🚀 Relaunching {{name}}…",
+      "relaunchFailed": "⚠️ Failed to relaunch {{name}}: {{error}}"
     }
   },
   "view": {

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -429,8 +429,8 @@
       "label": "시작 탭"
     },
     "noQuarantine": {
-      "title": "Cask 격리 건너뛰기",
-      "description": "Cask 설치 또는 업그레이드 시 macOS 격리 속성을 자동으로 제거합니다. 첫 실행 시 '앱이 손상되었습니다' 또는 Gatekeeper 경고를 방지합니다."
+      "title": "Remove Quarantine Attribute for Casks",
+      "description": "After installing or upgrading a cask, automatically remove the macOS quarantine attribute via xattr. This prevents the \"app is damaged\" or Gatekeeper warning on first launch. Does not use the deprecated --no-quarantine Homebrew flag."
     },
     "brewPath": {
       "title": "Homebrew 경로 설정",
@@ -565,6 +565,10 @@
         "hint": "'brew outdated' 명령에 대한 추가 인수. 예: --verbose, --formula, --cask. 위의 UI에서 구성된 outdated 플래그에 추가됩니다.",
         "preview": "새 인수"
       }
+    },
+    "autoRelaunch": {
+      "title": "Auto-Relaunch After Upgrade",
+      "description": "If a cask app is running when an upgrade begins, quit it first, then automatically relaunch it after quarantine removal completes. Requires 'Remove Quarantine Attribute' to be enabled."
     }
   },
   "backend": {
@@ -626,6 +630,17 @@
     },
     "outdated": {
       "autoUpdateCask": "이 자동 업데이트 앱은 이미 최신 상태일 수 있습니다. Homebrew에 기록된 설치 버전이 실제 앱 버전보다 늦을 수 있습니다."
+    },
+    "quarantine": {
+      "removing": "🔒 Removing quarantine attribute from {{path}}…",
+      "removed": "🔒 Quarantine attribute removed from {{path}}",
+      "removeFailed": "⚠️ Failed to remove quarantine from {{path}}: {{error}}",
+      "skippedPkg": "ℹ️ Quarantine removal skipped: {{name}} installs via .pkg (not a plain .app bundle)",
+      "resolveFailed": "⚠️ Could not resolve installed app path for {{name}}: {{error}}",
+      "quitting": "⏹ Quitting {{name}} before upgrade…",
+      "quitFailed": "⚠️ Failed to quit {{name}}: {{error}}",
+      "relaunching": "🚀 Relaunching {{name}}…",
+      "relaunchFailed": "⚠️ Failed to relaunch {{name}}: {{error}}"
     }
   },
   "view": {

--- a/frontend/src/i18n/locales/pt_BR.json
+++ b/frontend/src/i18n/locales/pt_BR.json
@@ -429,8 +429,8 @@
       "label": "Iniciar em"
     },
     "noQuarantine": {
-      "title": "Ignorar quarentena para casks",
-      "description": "Remove automaticamente o atributo de quarentena do macOS ao instalar ou atualizar casks. Evita o aviso de \"app danificado\" ou Gatekeeper na primeira execução."
+      "title": "Remove Quarantine Attribute for Casks",
+      "description": "After installing or upgrading a cask, automatically remove the macOS quarantine attribute via xattr. This prevents the \"app is damaged\" or Gatekeeper warning on first launch. Does not use the deprecated --no-quarantine Homebrew flag."
     },
     "brewPath": {
       "title": "Configuração do Caminho do Homebrew",
@@ -565,6 +565,10 @@
         "hint": "Argumentos adicionais para o comando 'brew outdated'. Exemplo: --verbose, --formula, --cask. Estes serão anexados à flag outdated configurada na interface acima.",
         "preview": "Novos argumentos"
       }
+    },
+    "autoRelaunch": {
+      "title": "Auto-Relaunch After Upgrade",
+      "description": "If a cask app is running when an upgrade begins, quit it first, then automatically relaunch it after quarantine removal completes. Requires 'Remove Quarantine Attribute' to be enabled."
     }
   },
   "backend": {
@@ -626,6 +630,17 @@
     },
     "outdated": {
       "autoUpdateCask": "Este aplicativo com atualização automática pode já estar atualizado. A versão de instalação registrada pelo Homebrew pode ficar atrás da versão real do aplicativo."
+    },
+    "quarantine": {
+      "removing": "🔒 Removing quarantine attribute from {{path}}…",
+      "removed": "🔒 Quarantine attribute removed from {{path}}",
+      "removeFailed": "⚠️ Failed to remove quarantine from {{path}}: {{error}}",
+      "skippedPkg": "ℹ️ Quarantine removal skipped: {{name}} installs via .pkg (not a plain .app bundle)",
+      "resolveFailed": "⚠️ Could not resolve installed app path for {{name}}: {{error}}",
+      "quitting": "⏹ Quitting {{name}} before upgrade…",
+      "quitFailed": "⚠️ Failed to quit {{name}}: {{error}}",
+      "relaunching": "🚀 Relaunching {{name}}…",
+      "relaunchFailed": "⚠️ Failed to relaunch {{name}}: {{error}}"
     }
   },
   "view": {

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -429,8 +429,8 @@
       "label": "Начинать с"
     },
     "noQuarantine": {
-      "title": "Пропустить карантин для cask",
-      "description": "Автоматически удаляет атрибут карантина macOS при установке или обновлении cask. Предотвращает предупреждение «приложение повреждено» или Gatekeeper при первом запуске."
+      "title": "Remove Quarantine Attribute for Casks",
+      "description": "After installing or upgrading a cask, automatically remove the macOS quarantine attribute via xattr. This prevents the \"app is damaged\" or Gatekeeper warning on first launch. Does not use the deprecated --no-quarantine Homebrew flag."
     },
     "brewPath": {
       "title": "Настройка пути Homebrew",
@@ -565,6 +565,10 @@
         "hint": "Дополнительные аргументы для команды 'brew outdated'. Например: --verbose, --formula, --cask. Они будут добавлены к флагу outdated, настроенному в интерфейсе выше.",
         "preview": "Новые аргументы"
       }
+    },
+    "autoRelaunch": {
+      "title": "Auto-Relaunch After Upgrade",
+      "description": "If a cask app is running when an upgrade begins, quit it first, then automatically relaunch it after quarantine removal completes. Requires 'Remove Quarantine Attribute' to be enabled."
     }
   },
   "backend": {
@@ -626,6 +630,17 @@
     },
     "outdated": {
       "autoUpdateCask": "Это приложение с автоматическим обновлением может уже быть актуальным. Записанная Homebrew версия установки может отставать от фактической версии приложения."
+    },
+    "quarantine": {
+      "removing": "🔒 Removing quarantine attribute from {{path}}…",
+      "removed": "🔒 Quarantine attribute removed from {{path}}",
+      "removeFailed": "⚠️ Failed to remove quarantine from {{path}}: {{error}}",
+      "skippedPkg": "ℹ️ Quarantine removal skipped: {{name}} installs via .pkg (not a plain .app bundle)",
+      "resolveFailed": "⚠️ Could not resolve installed app path for {{name}}: {{error}}",
+      "quitting": "⏹ Quitting {{name}} before upgrade…",
+      "quitFailed": "⚠️ Failed to quit {{name}}: {{error}}",
+      "relaunching": "🚀 Relaunching {{name}}…",
+      "relaunchFailed": "⚠️ Failed to relaunch {{name}}: {{error}}"
     }
   },
   "view": {

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -429,8 +429,8 @@
       "label": "Başlangıç"
     },
     "noQuarantine": {
-      "title": "Cask'lar için karantinayı atla",
-      "description": "Cask yüklerken veya güncellerken macOS karantina özniteliğini otomatik olarak kaldırır. İlk açılışta \"uygulama hasarlı\" veya Gatekeeper uyarısını önler."
+      "title": "Remove Quarantine Attribute for Casks",
+      "description": "After installing or upgrading a cask, automatically remove the macOS quarantine attribute via xattr. This prevents the \"app is damaged\" or Gatekeeper warning on first launch. Does not use the deprecated --no-quarantine Homebrew flag."
     },
     "brewPath": {
       "title": "Homebrew Yol Konfigürasyonu",
@@ -565,6 +565,10 @@
         "hint": "'brew outdated' komutu için ek argümanlar. Örnek: --verbose, --formula, --cask. Bunlar yukarıdaki arayüzde yapılandırılan outdated bayrağına eklenecektir.",
         "preview": "Yeni argümanlar"
       }
+    },
+    "autoRelaunch": {
+      "title": "Auto-Relaunch After Upgrade",
+      "description": "If a cask app is running when an upgrade begins, quit it first, then automatically relaunch it after quarantine removal completes. Requires 'Remove Quarantine Attribute' to be enabled."
     }
   },
   "backend": {
@@ -626,6 +630,17 @@
     },
     "outdated": {
       "autoUpdateCask": "Bu otomatik güncellenen uygulama zaten güncel olabilir. Homebrew'un kayıtlı kurulum sürümü gerçek uygulama sürümünün gerisinde kalabilir."
+    },
+    "quarantine": {
+      "removing": "🔒 Removing quarantine attribute from {{path}}…",
+      "removed": "🔒 Quarantine attribute removed from {{path}}",
+      "removeFailed": "⚠️ Failed to remove quarantine from {{path}}: {{error}}",
+      "skippedPkg": "ℹ️ Quarantine removal skipped: {{name}} installs via .pkg (not a plain .app bundle)",
+      "resolveFailed": "⚠️ Could not resolve installed app path for {{name}}: {{error}}",
+      "quitting": "⏹ Quitting {{name}} before upgrade…",
+      "quitFailed": "⚠️ Failed to quit {{name}}: {{error}}",
+      "relaunching": "🚀 Relaunching {{name}}…",
+      "relaunchFailed": "⚠️ Failed to relaunch {{name}}: {{error}}"
     }
   },
   "view": {

--- a/frontend/src/i18n/locales/zhCN.json
+++ b/frontend/src/i18n/locales/zhCN.json
@@ -429,8 +429,8 @@
       "label": "启动时显示"
     },
     "noQuarantine": {
-      "title": "跳过 Cask 隔离检疫",
-      "description": "安装或升级 Cask 时自动移除 macOS 隔离检疫属性。防止首次启动时出现「应用已损坏」或 Gatekeeper 警告。"
+      "title": "Remove Quarantine Attribute for Casks",
+      "description": "After installing or upgrading a cask, automatically remove the macOS quarantine attribute via xattr. This prevents the \"app is damaged\" or Gatekeeper warning on first launch. Does not use the deprecated --no-quarantine Homebrew flag."
     },
     "brewPath": {
       "title": "Homebrew 路径配置",
@@ -565,6 +565,10 @@
         "hint": "'brew outdated' 命令的额外参数。例如：--verbose、--formula、--cask。这些将附加到上面界面配置的 outdated 标志。",
         "preview": "新参数"
       }
+    },
+    "autoRelaunch": {
+      "title": "Auto-Relaunch After Upgrade",
+      "description": "If a cask app is running when an upgrade begins, quit it first, then automatically relaunch it after quarantine removal completes. Requires 'Remove Quarantine Attribute' to be enabled."
     }
   },
   "backend": {
@@ -626,6 +630,17 @@
     },
     "outdated": {
       "autoUpdateCask": "此自动更新应用可能已是最新版本。Homebrew 记录的安装版本可能落后于应用的实际版本。"
+    },
+    "quarantine": {
+      "removing": "🔒 Removing quarantine attribute from {{path}}…",
+      "removed": "🔒 Quarantine attribute removed from {{path}}",
+      "removeFailed": "⚠️ Failed to remove quarantine from {{path}}: {{error}}",
+      "skippedPkg": "ℹ️ Quarantine removal skipped: {{name}} installs via .pkg (not a plain .app bundle)",
+      "resolveFailed": "⚠️ Could not resolve installed app path for {{name}}: {{error}}",
+      "quitting": "⏹ Quitting {{name}} before upgrade…",
+      "quitFailed": "⚠️ Failed to quit {{name}}: {{error}}",
+      "relaunching": "🚀 Relaunching {{name}}…",
+      "relaunchFailed": "⚠️ Failed to relaunch {{name}}: {{error}}"
     }
   },
   "view": {

--- a/frontend/src/i18n/locales/zhTW.json
+++ b/frontend/src/i18n/locales/zhTW.json
@@ -429,8 +429,8 @@
       "label": "啟動時顯示"
     },
     "noQuarantine": {
-      "title": "跳過 Cask 隔離檢疫",
-      "description": "安裝或升級 Cask 時自動移除 macOS 隔離檢疫屬性。防止首次啟動時出現「應用程式已損壞」或 Gatekeeper 警告。"
+      "title": "Remove Quarantine Attribute for Casks",
+      "description": "After installing or upgrading a cask, automatically remove the macOS quarantine attribute via xattr. This prevents the \"app is damaged\" or Gatekeeper warning on first launch. Does not use the deprecated --no-quarantine Homebrew flag."
     },
     "brewPath": {
       "title": "Homebrew 路徑設定",
@@ -565,6 +565,10 @@
         "hint": "'brew outdated' 指令的額外參數。例如：--verbose、--formula、--cask。這些將附加到上面界面設定的 outdated 旗標。",
         "preview": "新參數"
       }
+    },
+    "autoRelaunch": {
+      "title": "Auto-Relaunch After Upgrade",
+      "description": "If a cask app is running when an upgrade begins, quit it first, then automatically relaunch it after quarantine removal completes. Requires 'Remove Quarantine Attribute' to be enabled."
     }
   },
   "backend": {
@@ -626,6 +630,17 @@
     },
     "outdated": {
       "autoUpdateCask": "此自動更新應用程式可能已是最新版本。Homebrew 記錄的安裝版本可能落後於應用程式的實際版本。"
+    },
+    "quarantine": {
+      "removing": "🔒 Removing quarantine attribute from {{path}}…",
+      "removed": "🔒 Quarantine attribute removed from {{path}}",
+      "removeFailed": "⚠️ Failed to remove quarantine from {{path}}: {{error}}",
+      "skippedPkg": "ℹ️ Quarantine removal skipped: {{name}} installs via .pkg (not a plain .app bundle)",
+      "resolveFailed": "⚠️ Could not resolve installed app path for {{name}}: {{error}}",
+      "quitting": "⏹ Quitting {{name}} before upgrade…",
+      "quitFailed": "⚠️ Failed to quit {{name}}: {{error}}",
+      "relaunching": "🚀 Relaunching {{name}}…",
+      "relaunchFailed": "⚠️ Failed to relaunch {{name}}: {{error}}"
     }
   },
   "view": {

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -78,6 +78,8 @@ export function GetMacOSVersion():Promise<string>;
 
 export function GetMirrorSource():Promise<Record<string, string>>;
 
+export function GetAutoRelaunch():Promise<boolean>;
+
 export function GetNoQuarantine():Promise<boolean>;
 
 export function GetOutdatedFlag():Promise<string>;
@@ -139,6 +141,8 @@ export function SetLandingTab(arg1:string):Promise<void>;
 export function SetLanguage(arg1:string):Promise<void>;
 
 export function SetMirrorSource(arg1:string,arg2:string):Promise<void>;
+
+export function SetAutoRelaunch(arg1:boolean):Promise<void>;
 
 export function SetNoQuarantine(arg1:boolean):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -150,6 +150,10 @@ export function GetMirrorSource() {
   return window['go']['main']['App']['GetMirrorSource']();
 }
 
+export function GetAutoRelaunch() {
+  return window['go']['main']['App']['GetAutoRelaunch']();
+}
+
 export function GetNoQuarantine() {
   return window['go']['main']['App']['GetNoQuarantine']();
 }
@@ -272,6 +276,10 @@ export function SetLanguage(arg1) {
 
 export function SetMirrorSource(arg1, arg2) {
   return window['go']['main']['App']['SetMirrorSource'](arg1, arg2);
+}
+
+export function SetAutoRelaunch(arg1) {
+  return window['go']['main']['App']['SetAutoRelaunch'](arg1);
 }
 
 export function SetNoQuarantine(arg1) {

--- a/i18n/helper.go
+++ b/i18n/helper.go
@@ -77,6 +77,15 @@ func (m *Manager) GetBackendMessage(key string, params map[string]string) string
 		"homebrewUpdateWarning":       "backend.homebrewUpdate.warning",
 		"errorStartingHomebrewUpdate": "backend.errors.startingHomebrewUpdate",
 		"autoUpdateCaskWarning":       "backend.outdated.autoUpdateCask",
+		"quarantine.removing":         "backend.quarantine.removing",
+		"quarantine.removed":          "backend.quarantine.removed",
+		"quarantine.removeFailed":     "backend.quarantine.removeFailed",
+		"quarantine.skippedPkg":       "backend.quarantine.skippedPkg",
+		"quarantine.resolveFailed":    "backend.quarantine.resolveFailed",
+		"quarantine.quitting":         "backend.quarantine.quitting",
+		"quarantine.quitFailed":       "backend.quarantine.quitFailed",
+		"quarantine.relaunching":      "backend.quarantine.relaunching",
+		"quarantine.relaunchFailed":   "backend.quarantine.relaunchFailed",
 	}
 
 	// Convert old key to new key format


### PR DESCRIPTION
Fixes #268

## Summary

After a successful **cask** install or upgrade, WailBrew now removes the `com.apple.quarantine` extended attribute from the installed `.app` itself:

```
xattr -r -d com.apple.quarantine "/Applications/<App>.app"
```

This avoids Gatekeeper's "app is damaged / cannot be opened" prompt on first launch.

### Why not `--no-quarantine`?

Homebrew is deprecating the `--no-quarantine` cask flag (as of Sep 2025 — see https://github.com/orgs/Homebrew/discussions/6537). So instead of passing that flag, we do the removal ourselves via `xattr(1)`. The flag has been removed from `buildCaskOpts()`.

### Relaunch on upgrade

If the app was **running** when an upgrade starts, we quit it gracefully via AppleScript (`tell application "X" to quit`, with a 10s poll + `pkill` fallback), remove the quarantine attribute, then relaunch it with `open`. This is controlled by a new **Auto-Relaunch After Update** setting (default **ON**).

## Changes

- **`backend/system/quarantine_darwin.go`** — `ResolveCaskAppPath` (parses `brew info --cask --json=v2` artifacts to find the real installed `.app`), `IsAppRunning`, `QuitAppGracefully`, `RemoveQuarantine`, `LaunchApp`. `quarantine_other.go` provides `//go:build !darwin` no-ops. Table-driven tests cover artifact parsing (app/pkg/precedence/leading-warning/empty).
- **`backend/brew/actions.go`** — `postInstallCask` helper wired into install, single update, and the bulk `UpdateSelectedBrewPackages` path (which issues one `brew upgrade` command, so it loops per-cask explicitly rather than relying on `RunUpdateCommand`). All quarantine/quit/relaunch failures are emitted as warning progress events and never fail the overall install/upgrade.
- **`.pkg`-based casks** are detected and skipped with an informational message.
- **Config** — the existing `NoQuarantine` setting now drives the `xattr` removal; new `AutoRelaunch bool` defaults to ON (seeded in `Config.Load()` so it stays true unless the user explicitly disables it).
- **Frontend** — new "Auto-Relaunch After Update" toggle in Settings + generated wails bindings.
- **i18n** — `settings.autoRelaunch` and `backend.quarantine.*` keys added to all 11 locale files; `noQuarantine` description updated to reflect the xattr approach.

## Testing

- `go build ./...` — passes
- `go test ./backend/...` — passes (includes new `parseCaskArtifacts` / `AppNameFromPath` tests)
- `gofmt -l` — clean

Manual verification to perform on a real machine (documented for reviewers):
1. Enable "Skip Quarantine", install a cask (e.g. `drawio`) → `xattr -l /Applications/draw.io.app` shows no quarantine line.
2. Open it, trigger an upgrade → app quits and relaunches.
3. Formula (non-cask) install/upgrade → no quarantine logic runs.
4. `.pkg`-based cask (e.g. `docker`) → informational skip message, upgrade still succeeds.
5. Auto-Relaunch OFF → quarantine removed but app not relaunched.
6. Skip Quarantine OFF → `xattr` never called.

## Known limitations

- `.pkg`-based casks skip quarantine removal (no single `.app` path to resolve).
- App running-detection uses `pgrep -x <BundleName>`; casks whose process name differs from the `.app` bundle name may not be detected as running (quarantine removal still happens; only auto-relaunch is skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)