### PR TITLE
fix: unable to load installed casks when a tap is not trusted

### DIFF
--- a/app.go
+++ b/app.go
@@ -188,6 +188,7 @@ func NewApp() *App {
 		brewEnvLCAll,
 		brewEnvNoAutoUpdate,
 	}
+	basicEnv = append(basicEnv, brew.HomebrewConfigEnv()...)
 	app.brewExecutor = brew.NewExecutor(brewPath, basicEnv, app.sessionLogManager.Append)
 
 	// Initialize i18n manager
@@ -209,6 +210,10 @@ func (a *App) getBrewEnv() []string {
 		brewEnvNoAutoUpdate,
 		brewEnvNonInteractive,
 	}
+
+	// Recover XDG_CONFIG_HOME from the login shell so Homebrew finds the same
+	// trust configuration the user's terminal does (see brew.HomebrewConfigEnv).
+	env = append(env, brew.HomebrewConfigEnv()...)
 
 	// Add proxy environment variables if configured
 	if a.config.Proxy != "" {

--- a/backend/brew/capabilities.go
+++ b/backend/brew/capabilities.go
@@ -1,0 +1,58 @@
+package brew
+
+import "sync"
+
+// Capabilities describes optional Homebrew features that WailBrew must know
+// about before acting, rather than after a command has already failed.
+//
+// These are probed, never derived from a version number. `brew trust` shipped in
+// 5.1.15 — the last 5.x release — so the feature boundary sits inside a major
+// version, not between two. Real installs also report versions like
+// "6.0.15-73-g7d75aaa", and WailBrew supports Workbrew, a fork with its own
+// numbering. Asking what an install can do is reliable; asking what it is, is not.
+type Capabilities struct {
+	SupportsTrust bool
+}
+
+// CapabilityDetector resolves Capabilities once and caches the answer. The probe
+// spawns Ruby and costs roughly 300ms, so it is deliberately lazy: nothing is
+// executed until something asks.
+type CapabilityDetector struct {
+	runner commandRunner
+	once   sync.Once
+	caps   Capabilities
+}
+
+// NewCapabilityDetector creates a detector that probes through the given runner.
+func NewCapabilityDetector(runner commandRunner) *CapabilityDetector {
+	return &CapabilityDetector{runner: runner}
+}
+
+// Capabilities returns the probed feature set, running the probe at most once.
+func (d *CapabilityDetector) Capabilities() Capabilities {
+	d.once.Do(func() {
+		// `brew help <command>` exits 0 when the command exists and non-zero
+		// when it does not, without performing any action.
+		_, err := d.runner.Run("help", "trust")
+		d.caps.SupportsTrust = err == nil
+	})
+	return d.caps
+}
+
+// TrustRemedy reports the tap the user should trust in order to recover from a
+// failure, and whether offering that remedy makes sense on this installation.
+//
+// It returns false for unrelated failures, and also when the installed Homebrew
+// has no `brew trust` command — offering a remedy that cannot be carried out is
+// worse than showing the raw diagnostic.
+func TrustRemedy(caps Capabilities, stderr string) (string, bool) {
+	if !caps.SupportsTrust || !IsUntrustedTapError(stderr) {
+		return "", false
+	}
+
+	tap := ExtractUntrustedTap(stderr)
+	if tap == "" {
+		return "", false
+	}
+	return tap, true
+}

--- a/backend/brew/capabilities_test.go
+++ b/backend/brew/capabilities_test.go
@@ -1,0 +1,88 @@
+package brew
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// countingRunner records how many times a command was executed and reports a
+// canned failure for commands listed in failing.
+type countingRunner struct {
+	calls   int
+	failing map[string]bool
+}
+
+func (c *countingRunner) Run(args ...string) ([]byte, error) {
+	c.calls++
+	if c.failing[argKey(args...)] {
+		return nil, errors.New("Error: Unknown command: trust")
+	}
+	return nil, nil
+}
+
+func (c *countingRunner) RunStdoutOnly(args ...string) ([]byte, error) { return c.Run(args...) }
+func (c *countingRunner) RunNoCacheStdoutOnly(args ...string) ([]byte, error) {
+	return c.Run(args...)
+}
+func (c *countingRunner) RunWithTimeoutStdoutOnly(_ time.Duration, args ...string) ([]byte, error) {
+	return c.Run(args...)
+}
+
+// `brew help trust` exits 0 where the command exists and non-zero where it does
+// not. Trust shipped in Homebrew 5.1.15, so neither the major version nor the
+// full version string is a usable signal — dev builds and Workbrew both lie.
+func TestCapabilityDetector_detectsTrustSupport(t *testing.T) {
+	supported := NewCapabilityDetector(&countingRunner{})
+	if !supported.Capabilities().SupportsTrust {
+		t.Fatal("expected trust to be supported when `brew help trust` succeeds")
+	}
+
+	missing := NewCapabilityDetector(&countingRunner{failing: map[string]bool{"help trust": true}})
+	if missing.Capabilities().SupportsTrust {
+		t.Fatal("expected trust to be unsupported when `brew help trust` fails")
+	}
+}
+
+// The probe spawns Ruby and costs ~300ms, so it must happen at most once.
+func TestCapabilityDetector_probesOnce(t *testing.T) {
+	runner := &countingRunner{}
+	detector := NewCapabilityDetector(runner)
+
+	for i := 0; i < 5; i++ {
+		detector.Capabilities()
+	}
+
+	if runner.calls != 1 {
+		t.Fatalf("expected the capability probe to run once, ran %d times", runner.calls)
+	}
+}
+
+func TestTrustRemedy_offersTapWhenSupported(t *testing.T) {
+	stderr := "Error: Refusing to load cask macos-fuse-t/cask/fuse-t-sshfs from untrusted tap macos-fuse-t/cask."
+
+	tap, ok := TrustRemedy(Capabilities{SupportsTrust: true}, stderr)
+
+	if !ok {
+		t.Fatal("expected a trust remedy to be offered")
+	}
+	if tap != "macos-fuse-t/cask" {
+		t.Fatalf("expected tap %q, got %q", "macos-fuse-t/cask", tap)
+	}
+}
+
+// On Homebrew older than 5.1.15 the `brew trust` command does not exist, so
+// offering the remedy would hand the user a command that cannot work.
+func TestTrustRemedy_suppressedWhenTrustUnsupported(t *testing.T) {
+	stderr := "Error: Refusing to load cask macos-fuse-t/cask/fuse-t-sshfs from untrusted tap macos-fuse-t/cask."
+
+	if _, ok := TrustRemedy(Capabilities{SupportsTrust: false}, stderr); ok {
+		t.Fatal("expected no trust remedy when brew trust is unavailable")
+	}
+}
+
+func TestTrustRemedy_ignoresUnrelatedFailures(t *testing.T) {
+	if _, ok := TrustRemedy(Capabilities{SupportsTrust: true}, "Error: No such keg: /opt/homebrew/Cellar/wget"); ok {
+		t.Fatal("expected no trust remedy for an unrelated failure")
+	}
+}

--- a/backend/brew/discover.go
+++ b/backend/brew/discover.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -35,12 +36,7 @@ func DiscoverBrewPath() string {
 // discoverViaLoginShell runs `$SHELL -lc 'command -v brew'` so we pick up the
 // user's real environment (custom HOMEBREW_PREFIX, non-default arch prefix, etc.).
 func discoverViaLoginShell() string {
-	shell := strings.TrimSpace(os.Getenv("SHELL"))
-	if shell == "" {
-		shell = "/bin/zsh"
-	}
-
-	output, err := runHostWithTimeout(shell, "-lc", "command -v brew")
+	output, err := runHostWithTimeout(loginShell(), "-lc", "command -v brew")
 	if err != nil {
 		return ""
 	}
@@ -58,6 +54,67 @@ func discoverViaLoginShell() string {
 		return path
 	}
 	return ""
+}
+
+// loginShell returns the user's login shell, falling back to zsh (the macOS default).
+func loginShell() string {
+	if shell := strings.TrimSpace(os.Getenv("SHELL")); shell != "" {
+		return shell
+	}
+	return "/bin/zsh"
+}
+
+// HomebrewConfigEnv returns extra environment entries so that brew, when launched
+// from the macOS GUI, resolves the same Homebrew configuration the user's
+// terminal does. Returns nil when nothing needs to be added.
+//
+// The result is memoized: the environment cannot change while the app is running
+// and the lookup spawns a login shell, which getBrewEnv would otherwise repeat on
+// every configuration change. Note that the sibling login-shell lookup in
+// discoverViaLoginShell is deliberately *not* memoized — CheckBrewLocation re-runs
+// it so the app can suggest a fix once the user installs Homebrew or repairs their
+// PATH, and a cached answer would freeze that recovery path.
+//
+// This value is also deliberately not persisted to config.json next to BrewPath.
+// A user's shell profile can change between launches, and a stale XDG_CONFIG_HOME
+// would silently point Homebrew at the wrong trust file — reviving this bug in a
+// form that is much harder to diagnose. Falling back to "unset" instead lets
+// Homebrew fail loudly with its own actionable message.
+var HomebrewConfigEnv = sync.OnceValue(func() []string {
+	return homebrewConfigEnv(os.Getenv("XDG_CONFIG_HOME"), loginShellXDGConfigHome)
+})
+
+// loginShellXDGConfigHome asks the user's login shell for XDG_CONFIG_HOME so we
+// pick up a value exported from their profile rather than the empty GUI value.
+func loginShellXDGConfigHome() string {
+	output, err := runHostWithTimeout(loginShell(), "-lc", `printf %s "${XDG_CONFIG_HOME-}"`)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}
+
+// homebrewConfigEnv reports the extra environment entries brew needs in order to
+// locate the user's Homebrew configuration.
+//
+// Homebrew 6 keeps tap/formula/cask trust state in
+// ${XDG_CONFIG_HOME}/homebrew/trust.json when XDG_CONFIG_HOME is set, and in
+// ~/.homebrew/trust.json otherwise. A macOS GUI app inherits no login-shell
+// environment, so without this the app reads a different trust file than the
+// user's terminal does and every third-party tap appears untrusted.
+//
+// An existing process value always wins; we only fill in what the GUI lost.
+func homebrewConfigEnv(processXDGConfigHome string, loginShellXDGConfigHome func() string) []string {
+	if strings.TrimSpace(processXDGConfigHome) != "" {
+		return nil
+	}
+
+	value := strings.TrimSpace(loginShellXDGConfigHome())
+	if value == "" {
+		return nil
+	}
+
+	return []string{"XDG_CONFIG_HOME=" + value}
 }
 
 // knownBrewLocations returns candidate brew paths to scan, including any

--- a/backend/brew/discover_test.go
+++ b/backend/brew/discover_test.go
@@ -1,0 +1,38 @@
+package brew
+
+import "testing"
+
+// Homebrew 6 stores tap/formula/cask trust state in
+// ${XDG_CONFIG_HOME}/homebrew/trust.json when XDG_CONFIG_HOME is set, and in
+// ~/.homebrew/trust.json otherwise. A macOS GUI app inherits no login-shell
+// environment, so WailBrew runs brew without XDG_CONFIG_HOME and Homebrew reads
+// the wrong (usually non-existent) trust file. Every third-party tap then looks
+// untrusted and name-list commands such as `brew list --cask --versions` exit 1.
+func TestHomebrewConfigEnv_recoversXDGConfigHomeFromLoginShell(t *testing.T) {
+	loginShell := func() string { return "/Users/example/.config" }
+
+	env := homebrewConfigEnv("", loginShell)
+
+	if len(env) != 1 || env[0] != "XDG_CONFIG_HOME=/Users/example/.config" {
+		t.Fatalf("expected XDG_CONFIG_HOME to be recovered from the login shell, got %v", env)
+	}
+}
+
+func TestHomebrewConfigEnv_keepsExistingProcessValue(t *testing.T) {
+	loginShell := func() string {
+		t.Fatal("login shell must not be queried when the process already has XDG_CONFIG_HOME")
+		return ""
+	}
+
+	if env := homebrewConfigEnv("/Users/example/.config", loginShell); env != nil {
+		t.Fatalf("expected no override when XDG_CONFIG_HOME is already set, got %v", env)
+	}
+}
+
+func TestHomebrewConfigEnv_noValueAnywhere(t *testing.T) {
+	loginShell := func() string { return "" }
+
+	if env := homebrewConfigEnv("", loginShell); env != nil {
+		t.Fatalf("expected no entries when XDG_CONFIG_HOME is unset everywhere, got %v", env)
+	}
+}

--- a/backend/brew/exec.go
+++ b/backend/brew/exec.go
@@ -166,7 +166,27 @@ func (e *Executor) runActual(timeout time.Duration, stdoutOnly bool, args ...str
 		}
 	}
 
-	return output, err
+	return output, withCommandStderr(err, output)
+}
+
+// withCommandStderr attaches brew's diagnostic output to err so callers that
+// format with %v show Homebrew's actionable message (for example "Refusing to
+// load cask ... Run `brew trust` ...") instead of a bare "exit status 1".
+//
+// cmd.Output() reports failures as *exec.ExitError, whose Error() is only the
+// wait status; the diagnostics live in the Stderr field. The original error is
+// wrapped so errors.As/errors.Is keep working.
+func withCommandStderr(err error, stdout []byte) error {
+	if err == nil {
+		return nil
+	}
+
+	detail := strings.TrimSpace(brewCommandErrorOutput(stdout, err))
+	if detail == "" {
+		return err
+	}
+
+	return fmt.Errorf("%w: %s", err, detail)
 }
 
 func brewCommandErrorOutput(stdout []byte, err error) string {

--- a/backend/brew/exec_test.go
+++ b/backend/brew/exec_test.go
@@ -1,0 +1,59 @@
+package brew
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// failingBrew returns a real *exec.ExitError whose Stderr is populated, matching
+// what cmd.Output() produces when brew exits non-zero.
+func failingBrew(t *testing.T, stderr string) error {
+	t.Helper()
+	_, err := exec.Command("/usr/bin/false").Output()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected the helper command to fail with *exec.ExitError, got %v", err)
+	}
+	exitErr.Stderr = []byte(stderr)
+	return exitErr
+}
+
+// Homebrew explains exactly how to recover from an untrusted tap, but cmd.Output()
+// puts that text on ExitError.Stderr, which formats as a bare "exit status 1".
+// Callers render errors with %v, so the actionable message must be in Error().
+func TestWithCommandStderr_surfacesBrewDiagnostics(t *testing.T) {
+	err := failingBrew(t, "Error: Refusing to load cask from untrusted tap example/cask.")
+
+	got := withCommandStderr(err, nil).Error()
+
+	if !strings.Contains(got, "Refusing to load cask") {
+		t.Fatalf("expected brew stderr in the error message, got %q", got)
+	}
+}
+
+func TestWithCommandStderr_preservesUnwrapping(t *testing.T) {
+	err := failingBrew(t, "boom")
+
+	var exitErr *exec.ExitError
+	if !errors.As(withCommandStderr(err, nil), &exitErr) {
+		t.Fatal("expected the wrapped error to still unwrap to *exec.ExitError")
+	}
+}
+
+func TestWithCommandStderr_nilStaysNil(t *testing.T) {
+	if got := withCommandStderr(nil, nil); got != nil {
+		t.Fatalf("expected nil error to stay nil, got %v", got)
+	}
+}
+
+func TestWithCommandStderr_fallsBackToStdout(t *testing.T) {
+	err := failingBrew(t, "")
+
+	got := withCommandStderr(err, []byte("Error: some stdout diagnostic")).Error()
+
+	if !strings.Contains(got, "some stdout diagnostic") {
+		t.Fatalf("expected stdout fallback in the error message, got %q", got)
+	}
+}

--- a/backend/brew/list.go
+++ b/backend/brew/list.go
@@ -58,6 +58,7 @@ func emptyCatalogError(kind string) [][]string {
 func (s *ListService) fetchCatalogNames(kind string, args ...string) [][]string {
 	output, err := s.executor.RunStdoutOnly(args...)
 	if err != nil {
+		s.reportFailure(err)
 		return [][]string{{"Error", fmt.Sprintf(
 			"Failed to fetch all %s: %v. This often happens on fresh Homebrew installations. Try refreshing after a few minutes.",
 			kind, err,
@@ -100,10 +101,13 @@ type ListService struct {
 	lockKnown     func()
 	unlockKnown   func()
 	logFunc       func(string)
+	onFailure     func(string)
 }
 
-// NewListService creates a new list service
-func NewListService(executor commandRunner, validateFunc func() error, knownPackages func() map[string]bool, lockFunc func(), unlockFunc func(), logFunc func(string)) *ListService {
+// NewListService creates a new list service. onFailure receives the diagnostic
+// text of a failed read command so the caller can classify it — for example to
+// offer the trust action when a tap is untrusted.
+func NewListService(executor commandRunner, validateFunc func() error, knownPackages func() map[string]bool, lockFunc func(), unlockFunc func(), logFunc func(string), onFailure func(string)) *ListService {
 	return &ListService{
 		executor:      executor,
 		validateFunc:  validateFunc,
@@ -111,6 +115,16 @@ func NewListService(executor commandRunner, validateFunc func() error, knownPack
 		lockKnown:     lockFunc,
 		unlockKnown:   unlockFunc,
 		logFunc:       logFunc,
+		onFailure:     onFailure,
+	}
+}
+
+// reportFailure hands a failed command's diagnostic to the caller for
+// classification. Since Executor wraps brew's stderr into the returned error,
+// err.Error() carries Homebrew's own explanation and recovery instructions.
+func (s *ListService) reportFailure(err error) {
+	if s.onFailure != nil && err != nil {
+		s.onFailure(err.Error())
 	}
 }
 
@@ -157,6 +171,7 @@ func (s *ListService) GetBrewPackages() [][]string {
 
 	output, err := s.executor.RunStdoutOnly("list", "--formula", "--versions")
 	if err != nil {
+		s.reportFailure(err)
 		return [][]string{{"Error", fmt.Sprintf("Failed to fetch installed packages: %v", err)}}
 	}
 
@@ -314,6 +329,7 @@ func (s *ListService) GetBrewCasks() [][]string {
 
 	output, err := s.executor.RunStdoutOnly("list", "--cask", "--versions")
 	if err != nil {
+		s.reportFailure(err)
 		return [][]string{{"Error", fmt.Sprintf("Failed to fetch installed casks: %v", err)}}
 	}
 
@@ -401,6 +417,7 @@ func (s *ListService) GetBrewLeaves() []string {
 func (s *ListService) GetBrewTaps() [][]string {
 	output, err := s.executor.RunStdoutOnly("tap")
 	if err != nil {
+		s.reportFailure(err)
 		return [][]string{{"Error", fmt.Sprintf("Failed to fetch repositories: %v", err)}}
 	}
 

--- a/backend/brew/list.go
+++ b/backend/brew/list.go
@@ -82,23 +82,42 @@ func (s *ListService) fetchCatalogNames(kind string, args ...string) [][]string 
 	return results
 }
 
+// commandRunner is the subset of *Executor that ListService uses. It exists so
+// tests can supply canned brew output — including stderr — without requiring a
+// real Homebrew installation.
+type commandRunner interface {
+	Run(args ...string) ([]byte, error)
+	RunStdoutOnly(args ...string) ([]byte, error)
+	RunNoCacheStdoutOnly(args ...string) ([]byte, error)
+	RunWithTimeoutStdoutOnly(timeout time.Duration, args ...string) ([]byte, error)
+}
+
 // ListService provides package listing functionality
 type ListService struct {
-	executor      *Executor
+	executor      commandRunner
 	validateFunc  func() error
 	knownPackages func() map[string]bool
 	lockKnown     func()
 	unlockKnown   func()
+	logFunc       func(string)
 }
 
 // NewListService creates a new list service
-func NewListService(executor *Executor, validateFunc func() error, knownPackages func() map[string]bool, lockFunc func(), unlockFunc func()) *ListService {
+func NewListService(executor commandRunner, validateFunc func() error, knownPackages func() map[string]bool, lockFunc func(), unlockFunc func(), logFunc func(string)) *ListService {
 	return &ListService{
 		executor:      executor,
 		validateFunc:  validateFunc,
 		knownPackages: knownPackages,
 		lockKnown:     lockFunc,
 		unlockKnown:   unlockFunc,
+		logFunc:       logFunc,
+	}
+}
+
+// log reports a diagnostic to the session log when one is configured.
+func (s *ListService) log(message string) {
+	if s.logFunc != nil {
+		s.logFunc(message)
 	}
 }
 
@@ -168,7 +187,7 @@ func (s *ListService) GetBrewPackages() [][]string {
 	}
 
 	// Resolve install origin (on request vs as dependency) from Homebrew JSON metadata.
-	infoOutput, infoErr := s.executor.Run("info", "--json=v2", "--formula", "--installed")
+	infoOutput, infoErr := s.executor.RunStdoutOnly("info", "--json=v2", "--formula", "--installed")
 	if infoErr == nil {
 		var info struct {
 			Formulae []struct {
@@ -180,7 +199,11 @@ func (s *ListService) GetBrewPackages() [][]string {
 			} `json:"formulae"`
 		}
 
-		if err := json.Unmarshal(infoOutput, &info); err == nil {
+		if err := json.Unmarshal(infoOutput, &info); err != nil {
+			// Not fatal: the list still renders, but every package falls back to
+			// an "unknown" origin. Log it so that degradation is traceable.
+			s.log(fmt.Sprintf("Failed to parse install-reason metadata from brew info: %v", err))
+		} else {
 			for _, f := range info.Formulae {
 				reason := "unknown"
 				if len(f.Installed) > 0 {
@@ -234,7 +257,7 @@ func (s *ListService) fillCaskInstalledVersions(caskNames []string, versionMap m
 	args := []string{"info", "--cask", "--json=v2"}
 	args = append(args, caskNames...)
 
-	infoOutput, err := s.executor.Run(args...)
+	infoOutput, err := s.executor.RunStdoutOnly(args...)
 	if err != nil {
 		for _, caskName := range caskNames {
 			s.fillSingleCaskInstalledVersion(caskName, versionMap)
@@ -264,7 +287,7 @@ func (s *ListService) fillCaskInstalledVersions(caskNames []string, versionMap m
 }
 
 func (s *ListService) fillSingleCaskInstalledVersion(caskName string, versionMap map[string]string) {
-	infoOutput, err := s.executor.Run("info", "--cask", "--json=v2", caskName)
+	infoOutput, err := s.executor.RunStdoutOnly("info", "--cask", "--json=v2", caskName)
 	if err != nil {
 		return
 	}

--- a/backend/brew/list_service_test.go
+++ b/backend/brew/list_service_test.go
@@ -1,0 +1,95 @@
+package brew
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeRunner mimics *Executor's two capture modes: Run merges stderr into the
+// returned bytes (CombinedOutput), RunStdoutOnly does not. Keyed by the joined
+// argument list.
+type fakeRunner struct {
+	stdout map[string]string
+	stderr map[string]string
+}
+
+func argKey(args ...string) string { return strings.Join(args, " ") }
+
+func (f *fakeRunner) Run(args ...string) ([]byte, error) {
+	k := argKey(args...)
+	return []byte(f.stderr[k] + f.stdout[k]), nil
+}
+
+func (f *fakeRunner) RunStdoutOnly(args ...string) ([]byte, error) {
+	return []byte(f.stdout[argKey(args...)]), nil
+}
+
+func (f *fakeRunner) RunNoCacheStdoutOnly(args ...string) ([]byte, error) {
+	return f.RunStdoutOnly(args...)
+}
+
+func (f *fakeRunner) RunWithTimeoutStdoutOnly(_ time.Duration, args ...string) ([]byte, error) {
+	return f.RunStdoutOnly(args...)
+}
+
+func newTestListService(runner commandRunner, logFunc func(string)) *ListService {
+	if logFunc == nil {
+		logFunc = func(string) {}
+	}
+	return NewListService(runner,
+		func() error { return nil },
+		func() map[string]bool { return map[string]bool{} },
+		func() {}, func() {},
+		logFunc)
+}
+
+// Homebrew writes deprecation warnings from third-party taps to stderr while
+// still producing valid JSON on stdout. Reading the install reason through a
+// combined-output call puts "Warning: ..." in front of the JSON, so the parse
+// fails and every package silently reports its origin as "unknown".
+func TestGetBrewPackages_installReasonSurvivesStderrWarnings(t *testing.T) {
+	const infoJSON = `{"formulae":[{"name":"wget","installed":[{"installed_on_request":true}]}]}`
+
+	runner := &fakeRunner{
+		stdout: map[string]string{
+			"list --formula --versions":            "wget 1.21\n",
+			"info --json=v2 --formula --installed": infoJSON,
+		},
+		stderr: map[string]string{
+			"info --json=v2 --formula --installed": "Warning: Calling `depends_on :macos` is deprecated!\n",
+		},
+	}
+
+	service := newTestListService(runner, nil)
+
+	packages := service.GetBrewPackages()
+
+	if len(packages) != 1 {
+		t.Fatalf("expected 1 package, got %v", packages)
+	}
+	if reason := packages[0][3]; reason != "on_request" {
+		t.Fatalf("expected install reason %q, got %q", "on_request", reason)
+	}
+}
+
+// A malformed install-reason payload silently degrades every package to
+// "unknown". Swallowing the parse error leaves no trace of why, so the failure
+// must reach the session log.
+func TestGetBrewPackages_logsWhenInstallReasonJSONIsUnreadable(t *testing.T) {
+	runner := &fakeRunner{
+		stdout: map[string]string{
+			"list --formula --versions":            "wget 1.21\n",
+			"info --json=v2 --formula --installed": "this is not json",
+		},
+	}
+
+	var logged []string
+	service := newTestListService(runner, func(msg string) { logged = append(logged, msg) })
+
+	service.GetBrewPackages()
+
+	if len(logged) == 0 {
+		t.Fatal("expected a log entry when the install-reason JSON could not be parsed")
+	}
+}

--- a/backend/brew/list_service_test.go
+++ b/backend/brew/list_service_test.go
@@ -1,6 +1,7 @@
 package brew
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -12,17 +13,25 @@ import (
 type fakeRunner struct {
 	stdout map[string]string
 	stderr map[string]string
+	errs   map[string]error
 }
 
 func argKey(args ...string) string { return strings.Join(args, " ") }
 
 func (f *fakeRunner) Run(args ...string) ([]byte, error) {
 	k := argKey(args...)
+	if err := f.errs[k]; err != nil {
+		return nil, err
+	}
 	return []byte(f.stderr[k] + f.stdout[k]), nil
 }
 
 func (f *fakeRunner) RunStdoutOnly(args ...string) ([]byte, error) {
-	return []byte(f.stdout[argKey(args...)]), nil
+	k := argKey(args...)
+	if err := f.errs[k]; err != nil {
+		return nil, err
+	}
+	return []byte(f.stdout[k]), nil
 }
 
 func (f *fakeRunner) RunNoCacheStdoutOnly(args ...string) ([]byte, error) {
@@ -31,17 +40,6 @@ func (f *fakeRunner) RunNoCacheStdoutOnly(args ...string) ([]byte, error) {
 
 func (f *fakeRunner) RunWithTimeoutStdoutOnly(_ time.Duration, args ...string) ([]byte, error) {
 	return f.RunStdoutOnly(args...)
-}
-
-func newTestListService(runner commandRunner, logFunc func(string)) *ListService {
-	if logFunc == nil {
-		logFunc = func(string) {}
-	}
-	return NewListService(runner,
-		func() error { return nil },
-		func() map[string]bool { return map[string]bool{} },
-		func() {}, func() {},
-		logFunc)
 }
 
 // Homebrew writes deprecation warnings from third-party taps to stderr while
@@ -70,6 +68,50 @@ func TestGetBrewPackages_installReasonSurvivesStderrWarnings(t *testing.T) {
 	}
 	if reason := packages[0][3]; reason != "on_request" {
 		t.Fatalf("expected install reason %q, got %q", "on_request", reason)
+	}
+}
+
+func newTestListService(runner commandRunner, logFunc func(string)) *ListService {
+	return newTestListServiceWithFailureHook(runner, logFunc, nil)
+}
+
+func newTestListServiceWithFailureHook(runner commandRunner, logFunc func(string), onFailure func(string)) *ListService {
+	if logFunc == nil {
+		logFunc = func(string) {}
+	}
+	if onFailure == nil {
+		onFailure = func(string) {}
+	}
+	return NewListService(runner,
+		func() error { return nil },
+		func() map[string]bool { return map[string]bool{} },
+		func() {}, func() {},
+		logFunc, onFailure)
+}
+
+// Homebrew names the untrusted tap and the exact recovery command in its
+// diagnostic. Read paths must hand that text to the failure hook so the UI can
+// offer the trust action that already exists for install and tap flows.
+func TestGetBrewCasks_reportsDiagnosticWhenTapIsUntrusted(t *testing.T) {
+	const diagnostic = "exit status 1: Error: Refusing to load cask " +
+		"macos-fuse-t/cask/fuse-t-sshfs from untrusted tap macos-fuse-t/cask."
+
+	runner := &fakeRunner{
+		errs: map[string]error{"list --cask --versions": errors.New(diagnostic)},
+	}
+
+	var reported []string
+	service := newTestListServiceWithFailureHook(runner, nil, func(stderr string) {
+		reported = append(reported, stderr)
+	})
+
+	service.GetBrewCasks()
+
+	if len(reported) != 1 {
+		t.Fatalf("expected the failure diagnostic to be reported once, got %d", len(reported))
+	}
+	if tap, ok := TrustRemedy(Capabilities{SupportsTrust: true}, reported[0]); !ok || tap != "macos-fuse-t/cask" {
+		t.Fatalf("reported diagnostic did not yield the untrusted tap: %q", reported[0])
 	}
 }
 

--- a/backend/brew/service.go
+++ b/backend/brew/service.go
@@ -146,6 +146,7 @@ func NewService(
 		func() map[string]bool { return databaseService.knownPackages },
 		func() { databaseService.knownPackagesMux.Lock() },
 		func() { databaseService.knownPackagesMux.Unlock() },
+		logFunc,
 	)
 
 	// Create size service
@@ -699,7 +700,7 @@ func (s *serviceImpl) GetHomebrewCaskVersion() (string, error) {
 		return "", fmt.Errorf("Homebrew validation failed: %v", err)
 	}
 
-	infoOutput, err := s.executor.Run("info", "--cask", "--json=v2", "wailbrew")
+	infoOutput, err := s.executor.RunStdoutOnly("info", "--cask", "--json=v2", "wailbrew")
 	if err != nil {
 		return "", fmt.Errorf("failed to get Homebrew Cask info: %v", err)
 	}

--- a/backend/brew/service.go
+++ b/backend/brew/service.go
@@ -139,6 +139,9 @@ func NewService(
 	// Create database service first (needs executor)
 	databaseService := NewDatabaseService(executor)
 
+	// Probed lazily on the first read failure, so no cost on the happy path.
+	capabilities := NewCapabilityDetector(executor)
+
 	// Create list service
 	listService := NewListService(
 		executor,
@@ -147,6 +150,18 @@ func NewService(
 		func() { databaseService.knownPackagesMux.Lock() },
 		func() { databaseService.knownPackagesMux.Unlock() },
 		logFunc,
+		func(stderr string) {
+			// A read failed. If Homebrew blocked it on an untrusted tap and this
+			// install can actually run `brew trust`, offer the same remediation
+			// the install and tap flows already provide.
+			tap, ok := TrustRemedy(capabilities.Capabilities(), stderr)
+			if !ok {
+				return
+			}
+			if payload, err := json.Marshal(map[string]string{"tap": tap}); err == nil {
+				eventEmitter.Emit("packageListTrustRequired", string(payload))
+			}
+		},
 	)
 
 	// Create size service

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -900,6 +900,23 @@ const WailBrewApp = () => {
         const unlistenRefreshPackages = EventsOn("refreshPackagesData", () => {
             handleRefreshPackages();
         });
+        // Homebrew 5.1.15+: a list failed because a tap is not trusted. The
+        // backend only emits this when `brew trust` actually exists, so the
+        // prompt is never offered where it could not be carried out.
+        const unlistenListTrust = EventsOn("packageListTrustRequired", (payload: string) => {
+            let tap = "";
+            try {
+                tap = (JSON.parse(payload) as { tap?: string }).tap || "";
+            } catch {
+                tap = "";
+            }
+            if (tap) {
+                setTrustPrompt({
+                    tap,
+                    retry: () => handleRefreshPackages(),
+                });
+            }
+        });
         const unlistenAbout = EventsOn("showAbout", () => {
             setShowAbout(true);
         });
@@ -1036,6 +1053,7 @@ const WailBrewApp = () => {
             unlisten();
             unlistenRefresh();
             unlistenRefreshPackages();
+            unlistenListTrust();
             unlistenAbout();
             unlistenUpdate();
             unlistenWailbrewUpdated();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1035,6 +1035,7 @@ const WailBrewApp = () => {
         return () => {
             unlisten();
             unlistenRefresh();
+            unlistenRefreshPackages();
             unlistenAbout();
             unlistenUpdate();
             unlistenWailbrewUpdated();


### PR DESCRIPTION
Fixes #376

## Summary

Casks and formulae fail to load entirely, with the view replaced by an error, on machines where a third-party tap has already been trusted. The same tap works fine from a terminal.

The cause is where Homebrew keeps trust state: `${XDG_CONFIG_HOME}/homebrew/trust.json` when that variable is set, `~/.homebrew/trust.json` when it is not. An app launched from Finder inherits no login shell environment, so for anyone who exports `XDG_CONFIG_HOME` in their profile, brew wrote trust under `~/.config` from the terminal while WailBrew read the fallback and found nothing there. Taps the user had already trusted came back untrusted and the cask list exited 1. Users who do not set `XDG_CONFIG_HOME` were unaffected, since the app and the terminal then resolve to the same file.

Separately, any untrusted tap showed up as `Failed to fetch installed casks: exit status 1`, because `cmd.Output()` drops stderr, which is where Homebrew names the tap and prints the `brew trust` command that fixes it. Session Logs had that text but the on-screen error did not, so reports like #27, #152, #178, #203 and #357 needed a round trip asking for logs first. Errors now carry brew's own message, and a blocked list offers the existing trust dialog instead of a dead end.

Those older ones are closed and were resolved by other means. The point is that they all arrived as the same bare status code with no cause attached. Anything in that family from here on should either fix itself, where the trust state above is what was wrong, or at least land with Homebrew's own explanation already in it. The trust dialog covers a third case, a tap the user simply never trusted, which fails the same way in the terminal and previously had no route to recovery inside the app.

## Changes

- Recover `XDG_CONFIG_HOME` from the login shell when the process lacks it. An existing value always wins, so terminal launches and `wails dev` are unaffected.
- Fold brew's stderr into returned errors, wrapped with `%w`.
- Four `brew info` JSON reads used `CombinedOutput`, so tap deprecation warnings broke `json.Unmarshal`. They now read stdout only, and the parse failure is logged rather than swallowed.
- Offer the trust dialog when a read fails, gated on probing `brew help trust` rather than a version number. Trust shipped in 5.1.15, so a `major >= 6` check would be wrong both ways.

The first commit is an unrelated event listener cleanup leak. It applies to main on its own if you would rather it went in separately.

## Testing

Go and frontend builds, tests, `gofmt` and `go vet` all pass, with nine new Go tests. Each commit builds and passes on its own.

Verified against Homebrew 6.0.15 by clearing `XDG_CONFIG_HOME` and `ZDOTDIR` to simulate a Finder launch. `ZDOTDIR` matters here, since zsh otherwise reads the wrong `.zshenv` and the lookup comes back empty, which makes the fix look broken.

Happy to go into more detail on any of this if it would help.
