### PR TITLE
fix: tolerate noisy login shell output

### DIFF
--- a/backend/brew/discover.go
+++ b/backend/brew/discover.go
@@ -41,17 +41,20 @@ func discoverViaLoginShell() string {
 		return ""
 	}
 
-	path := strings.TrimSpace(string(output))
-	// `command -v` may emit more than one line; the executable path is first.
-	if idx := strings.IndexByte(path, '\n'); idx >= 0 {
-		path = strings.TrimSpace(path[:idx])
-	}
-	if path == "" {
-		return ""
-	}
+	return workingBrewPathFromShellOutput(output, isWorkingBrew)
+}
 
-	if isWorkingBrew(path) {
-		return path
+// workingBrewPathFromShellOutput finds the actual `command -v brew` result
+// without assuming the login shell is silent. Shell startup files may print
+// diagnostics before or after the command output, so candidates are checked
+// from the end and accepted only when they point to a working brew executable.
+func workingBrewPathFromShellOutput(output []byte, isWorking func(string) bool) string {
+	lines := strings.Split(string(output), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		candidate := strings.TrimSpace(lines[i])
+		if candidate != "" && isWorking(candidate) {
+			return candidate
+		}
 	}
 	return ""
 }
@@ -84,14 +87,34 @@ var HomebrewConfigEnv = sync.OnceValue(func() []string {
 	return homebrewConfigEnv(os.Getenv("XDG_CONFIG_HOME"), loginShellXDGConfigHome)
 })
 
-// loginShellXDGConfigHome asks the user's login shell for XDG_CONFIG_HOME so we
-// pick up a value exported from their profile rather than the empty GUI value.
+// loginShellXDGConfigHome asks the user's login shell for its environment so we
+// pick up XDG_CONFIG_HOME exported by the profile rather than the empty GUI
+// value. Parsing the env output avoids treating unrelated startup diagnostics
+// as the variable value.
 func loginShellXDGConfigHome() string {
-	output, err := runHostWithTimeout(loginShell(), "-lc", `printf %s "${XDG_CONFIG_HOME-}"`)
+	output, err := runHostWithTimeout(loginShell(), "-lc", `/usr/bin/printf '\0'; /usr/bin/env -0`)
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(output))
+	return environmentValueFromShellOutput(output, "XDG_CONFIG_HOME")
+}
+
+// environmentValueFromShellOutput extracts an exact KEY=value entry from the
+// NUL-delimited environment snapshot. The first NUL separates startup output
+// from env records; the final NUL keeps any shell-exit output outside them.
+func environmentValueFromShellOutput(output []byte, key string) string {
+	prefix := key + "="
+	records := strings.Split(string(output), "\x00")
+	if len(records) < 3 {
+		return ""
+	}
+
+	for _, record := range records[1 : len(records)-1] {
+		if strings.HasPrefix(record, prefix) {
+			return strings.TrimSpace(strings.TrimPrefix(record, prefix))
+		}
+	}
+	return ""
 }
 
 // homebrewConfigEnv reports the extra environment entries brew needs in order to

--- a/backend/brew/discover_test.go
+++ b/backend/brew/discover_test.go
@@ -2,6 +2,55 @@ package brew
 
 import "testing"
 
+func TestWorkingBrewPathFromShellOutput_ignoresStartupNoise(t *testing.T) {
+	output := []byte("loading profile\n/custom/homebrew/bin/brew\nlogin shell ready\n")
+	checked := make([]string, 0)
+
+	path := workingBrewPathFromShellOutput(output, func(candidate string) bool {
+		checked = append(checked, candidate)
+		return candidate == "/custom/homebrew/bin/brew"
+	})
+
+	if path != "/custom/homebrew/bin/brew" {
+		t.Fatalf("expected working brew path, got %q", path)
+	}
+	if len(checked) != 2 || checked[0] != "login shell ready" {
+		t.Fatalf("expected candidates to be checked from the end, got %v", checked)
+	}
+}
+
+func TestWorkingBrewPathFromShellOutput_noWorkingCandidate(t *testing.T) {
+	output := []byte("loading profile\ncommand not found\n")
+
+	if path := workingBrewPathFromShellOutput(output, func(string) bool { return false }); path != "" {
+		t.Fatalf("expected no path, got %q", path)
+	}
+}
+
+func TestEnvironmentValueFromShellOutput_ignoresStartupNoise(t *testing.T) {
+	output := []byte("zprofile\n\x00HOME=/Users/example\x00XDG_CONFIG_HOME=/Users/example/.config\x00")
+
+	if value := environmentValueFromShellOutput(output, "XDG_CONFIG_HOME"); value != "/Users/example/.config" {
+		t.Fatalf("expected XDG_CONFIG_HOME from environment output, got %q", value)
+	}
+}
+
+func TestEnvironmentValueFromShellOutput_ignoresShellExitNoise(t *testing.T) {
+	output := []byte("XDG_CONFIG_HOME=/printed/by/profile\n\x00HOME=/Users/example\x00XDG_CONFIG_HOME=/actual/value\x00XDG_CONFIG_HOME=/printed/by/logout\n")
+
+	if value := environmentValueFromShellOutput(output, "XDG_CONFIG_HOME"); value != "/actual/value" {
+		t.Fatalf("expected the delimited environment entry, got %q", value)
+	}
+}
+
+func TestEnvironmentValueFromShellOutput_missingValue(t *testing.T) {
+	output := []byte("zprofile\n\x00HOME=/Users/example\x00SHELL=/bin/zsh\x00")
+
+	if value := environmentValueFromShellOutput(output, "XDG_CONFIG_HOME"); value != "" {
+		t.Fatalf("expected no XDG_CONFIG_HOME, got %q", value)
+	}
+}
+
 // Homebrew 6 stores tap/formula/cask trust state in
 // ${XDG_CONFIG_HOME}/homebrew/trust.json when XDG_CONFIG_HOME is set, and in
 // ~/.homebrew/trust.json otherwise. A macOS GUI app inherits no login-shell


### PR DESCRIPTION
## Summary

- tolerate diagnostic output from login-shell startup and exit files
- recover `XDG_CONFIG_HOME` from a delimited environment snapshot instead of treating all stdout as its value
- scan shell output for a working Homebrew path instead of assuming the first line is the path
- add regression tests for noisy shell output and missing values

## Problem

WailBrew launches the user's login shell to discover Homebrew and recover `XDG_CONFIG_HOME` for GUI launches. The current parsing assumes that shell initialization is silent.

That assumption does not always hold. Users may intentionally print diagnostics from files such as `.zprofile`, and shell frameworks or custom setup scripts can produce output as well. For example, if a profile prints `loading profile` while `XDG_CONFIG_HOME` is unset, WailBrew currently interprets that text as the value and launches Homebrew with:

```text
XDG_CONFIG_HOME=loading profile
```

Homebrew then looks for configuration and trust state in the wrong location. A formula or tap that is trusted in the terminal can appear untrusted in WailBrew, causing list or info commands to fail. When a batched formula-size lookup contains that formula, the failure can surface as `Unknown` for the entire batch.

The same noisy-output assumption also affects `command -v brew`: an unrelated first line makes shell-based discovery fail and forces WailBrew to rely on fallback locations.

## Changes

- Prefix the login-shell environment snapshot with a NUL boundary and use `env -0`, so visible startup and exit diagnostics remain outside the parsed environment records.
- Extract only the exact `XDG_CONFIG_HOME=...` record from that snapshot. If the variable is unset, no override is added and Homebrew uses its normal fallback.
- Check login-shell output lines from the end and accept only a candidate that passes the existing Homebrew validation.
- Cover startup noise, exit noise, missing variables, valid paths, and missing paths in unit tests.

## Testing

- `go test ./backend/brew`
- `go test ./...`
- `go build ./...`
- `go vet ./...`
- `pnpm --dir frontend run build`
- `pnpm --dir frontend test` (24 tests)

Also reproduced the original failure locally by launching Homebrew with the incorrectly inferred relative `XDG_CONFIG_HOME`, then verified that the delimited parser returns the actual exported value or no override when it is unset.
