### PR TITLE
fix: correctly extract package name from sharded Formula/Casks paths in ParseWarnings

### DIFF
--- a/backend/brew/warnings.go
+++ b/backend/brew/warnings.go
@@ -60,8 +60,10 @@ func ParseWarnings(warnings string) map[string]string {
 	var currentPackage string
 
 	for _, line := range lines {
-		// Check if line contains a formula/cask file path
-		// Format: /path/to/Taps/username/homebrew-tap/Formula/package-name.rb:12
+		// Check if line contains a formula/cask file path.
+		// homebrew-core and homebrew-cask (and other large taps) shard their
+		// Formula/Casks directory by the package's first character, so the
+		// path looks like .../Formula/j/jq.rb:12 rather than .../Formula/jq.rb:12.
 		if strings.Contains(line, "/Formula/") || strings.Contains(line, "/Casks/") {
 			// Save accumulated warning for the previous package before switching
 			if currentPackage != "" {
@@ -77,13 +79,16 @@ func ParseWarnings(warnings string) map[string]string {
 			}
 
 			if formulaPath != "" {
-				// Extract package name (remove .rb extension and line numbers)
+				// Extract package name (remove line numbers and .rb extension)
 				packageName := formulaPath
-				if idx := strings.Index(packageName, ".rb"); idx != -1 {
-					packageName = packageName[:idx]
-				}
 				if idx := strings.Index(packageName, ":"); idx != -1 {
 					packageName = packageName[:idx]
+				}
+				packageName = strings.TrimSuffix(packageName, ".rb")
+				// Drop any shard subdirectory (e.g. "j/jq" -> "jq") so the
+				// name matches the plain package names brew outdated reports.
+				if idx := strings.LastIndex(packageName, "/"); idx != -1 {
+					packageName = packageName[idx+1:]
 				}
 				currentPackage = packageName
 				currentWarning.Reset()

--- a/backend/brew/warnings_test.go
+++ b/backend/brew/warnings_test.go
@@ -1,0 +1,73 @@
+package brew
+
+import "testing"
+
+// homebrew-core and homebrew-cask shard their Formula/ and Casks/ directories
+// by the package's first character (e.g. Formula/j/jq.rb, Casks/w/wailbrew.rb)
+// to keep the directory listing manageable. Any tap can do the same for large
+// enough collections. ParseWarnings must key its result by the plain package
+// name in either layout so callers can look it up with the name brew itself
+// reports (e.g. from `brew outdated --json=v2`).
+
+func TestParseWarnings_shardedFormulaPath(t *testing.T) {
+	warnings := "/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/j/jq.rb:24: warning: instance variable @build_bottle not initialized\n"
+
+	result := ParseWarnings(warnings)
+
+	if _, found := result["jq"]; !found {
+		t.Fatalf("expected warning keyed by plain package name %q, got keys %v", "jq", keysOf(result))
+	}
+	if _, found := result["j/jq"]; found {
+		t.Fatalf("warning incorrectly keyed by shard-prefixed name %q, keys %v", "j/jq", keysOf(result))
+	}
+}
+
+func TestParseWarnings_shardedCaskPath(t *testing.T) {
+	warnings := "/opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/w/wailbrew.rb:3: warning: something happened\n"
+
+	result := ParseWarnings(warnings)
+
+	if _, found := result["wailbrew"]; !found {
+		t.Fatalf("expected warning keyed by plain package name %q, got keys %v", "wailbrew", keysOf(result))
+	}
+}
+
+func TestParseWarnings_flatTapPathStillWorks(t *testing.T) {
+	// Smaller third-party taps are not sharded, e.g. Formula/supabase.rb directly.
+	warnings := "/opt/homebrew/Library/Taps/supabase/homebrew-tap/Formula/supabase.rb:5: warning: deprecated call\n"
+
+	result := ParseWarnings(warnings)
+
+	if _, found := result["supabase"]; !found {
+		t.Fatalf("expected warning keyed by plain package name %q, got keys %v", "supabase", keysOf(result))
+	}
+}
+
+func TestParseWarnings_multiplePackagesEachGetTheirOwnWarning(t *testing.T) {
+	warnings := "" +
+		"/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/a/aws-sdk-cpp.rb:1: warning: first\n" +
+		"/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/j/jq.rb:2: warning: second\n"
+
+	result := ParseWarnings(warnings)
+
+	if v := result["aws-sdk-cpp"]; v == "" {
+		t.Fatalf("expected a warning for aws-sdk-cpp, keys %v", keysOf(result))
+	}
+	if v := result["jq"]; v == "" {
+		t.Fatalf("expected a warning for jq, keys %v", keysOf(result))
+	}
+}
+
+func TestParseWarnings_emptyInput(t *testing.T) {
+	if result := ParseWarnings(""); len(result) != 0 {
+		t.Fatalf("expected empty map for empty input, got %v", result)
+	}
+}
+
+func keysOf(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}


### PR DESCRIPTION
I was looking at how the Outdated view attaches brew's stderr warnings to individual packages (`ParseWarnings` in `backend/brew/warnings.go`) and noticed the code's own comment describes the path format as `.../Taps/username/homebrew-tap/Formula/package-name.rb:12` — a flat layout. That's not how homebrew-core or homebrew-cask lay out their formulae/casks any more: both shard the directory by the package's first character to keep it from becoming one giant folder, e.g. `Formula/j/jq.rb` and `Casks/w/wailbrew.rb` (any large enough third-party tap can do the same).

Since the parser took everything between `/Formula/` and `.rb` as the package name, a warning tied to a sharded formula got keyed as `"j/jq"` instead of `"jq"`. `GetBrewUpdatablePackages` in `outdated.go` looks the warning up by the plain name `brew outdated --json=v2` reports, so that lookup silently misses and the warning never reaches the UI for the affected package.

This is admittedly narrow — it only bites when the warning actually carries a `/Formula/` or `/Casks/` path from a sharded tap, which needs a locally-checked-out tap (`brew tap homebrew/core`, `HOMEBREW_NO_INSTALL_FROM_API=1`, or a large third-party tap) rather than the default API-only installs, so it's easy to not notice. But when it does fire, the warning just silently disappears instead of showing up next to the package, which seems worth fixing since the whole point of that code is to surface the warning.

**Fix:** take only the last path segment as the package name instead of everything before `.rb`, so it works regardless of shard depth. Flat tap layouts (e.g. small custom taps with `Formula/name.rb` directly) keep working exactly as before.

Also added `backend/brew/warnings_test.go` — there wasn't a test file for this function yet, so I added coverage for the sharded case (formula + cask), the pre-existing flat-tap case, and the multi-package accumulation behavior that was already fixed once before in this file (so that fix stays pinned too).

### Testing
- `cd frontend && pnpm run build && pnpm run lint && pnpm run test` — clean, unaffected (no frontend files touched)
- `go build ./...`, `go test ./...` — all packages pass, including the new tests
- `golangci-lint run` (whole module) — 0 issues
- Confirmed the regression: stashing just the fix and re-running the new tests reproduces the bug (`j/jq`, `w/wailbrew` instead of `jq`, `wailbrew`); un-stashing fixes it
- Verified the sharded directory layout directly against `Homebrew/homebrew-core` and `Homebrew/homebrew-cask` on GitHub rather than assuming it